### PR TITLE
Pulse IOSTAT Collector Plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+.idea
+tmp/
+*.tmp
+scratch/
+build/
+*.swp
+profile.cov
+gin-bin
+
+# we don't vendor godep _workspace
+**/Godeps/_workspace/**
+
+# OSX stuff
+.DS_Store

--- a/.netrc
+++ b/.netrc
@@ -1,0 +1,3 @@
+machine github.com
+  login intelsdibot
+  password 0f60cedb3c004ae0a79c24e6b30ce416ab4fcc49

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+sudo: required
+language: go
+go:
+- 1.4.2
+- 1.5
+env:
+  global:
+    - SNAP_PLUGIN_SOURCE=/home/travis/gopath/src/github.com/intelsdi-x/snap-plugin-collector-iostat
+  matrix:
+    - TEST=unit
+before_install:
+- cp .netrc ~
+- chmod 600 .netrc
+- go get github.com/tools/godep
+- if [ ! -d $SNAP_PLUGIN_SOURCE ]; then mkdir -p $HOME/gopath/src/github.com/intelsdi-x; ln -s $TRAVIS_BUILD_DIR $SNAP_PLUGIN_SOURCE; fi # CI for forks not from intelsdi-x
+install:
+- export TMPDIR=$HOME/tmp
+- mkdir -p $TMPDIR
+- cd $SNAP_PLUGIN_SOURCE # change dir into source
+- make deps
+script:
+- make check TEST=$TEST 2>&1 # Run test suite
+notifications:
+  slack:
+    secure: VkbZLIc2RH8yf3PtIAxUNPdAu3rQQ7yQx0GcK124JhbEnZGaHyK615V0rbG7HcVmYKGPdB0cXqZiLBDKGqGKb2zR1NepOe1nF03jxGSpPq8jIFeEXSJGEYGL34ScDzZZGuG6qwbjFcXiW5lqn6t8igzp7v2+URYBaZo5ktCS2xY=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Snap Collector Plugin - IOSTAT
+
+1. [Contributing Code](#contributing-code)
+1. [Contributing Examples](#contributing-examples)
+1. [Contribute Elsewhere](#contribute-elsewhere)
+1. [Thank You](#thank-you)
+
+
+This repository is primarily **community supported**. We both appreciate and need your contribution to keep it stable.
+
+Thank you for being part of the community! We love you for it.
+
+## Contributing Code
+**_IMPORTANT_**: We encourage contributions to the project from the community. We ask that you keep the following guidelines in mind when planning your contribution.
+
+* Whether your contribution is for a bug fix or a feature request, **create an [Issue](https://github.com/TODO LINK/issues)** and let us know what you are thinking
+* **For bugs**, if you have already found a fix, feel free to submit a Pull Request referencing the Issue you created
+* **For feature requests**, we want to improve upon the library incrementally which means small changes at a time. In order ensure your PR can be reviewed in a timely manner, please keep PRs small, e.g. <10 files and <500 lines changed. If you think this is unrealistic, then mention that within the issue and we can discuss it
+
+Once you're ready to contribute code back to this repo, start with these steps:
+
+* Fork the appropriate sub-projects that are affected by your change
+* Create a topic branch for your change and checkout that branch  
+     ```
+     $ git checkout -b some-topic-branch
+     ```
+* Make your changes and run the test suite if one is provided (see below)
+* Commit your changes and push them to your fork
+* Open a pull request for the appropriate project
+* Contributors will review your pull request, suggest changes, and merge it when i's ready and/or offer feedback
+* To report a bug or issue, please open a new issue against this repository
+
+If you have questions feel free to contact the [maintainers](README.md#maintainers).
+
+## Contributing Examples
+The most immediately helpful way you can benefit this project is by cloning the repository, adding some further examples and submitting a pull request.
+
+Have you written a blog post about how you use $PROJECT? Send it to us! << TODO Where?
+
+
+## Contribute Elsewhere
+This repository is one of **many** plugins in the **snap Framework**: a powerful telemetry agent framework. See the full project at http://github.com/intelsdi-x/snap
+
+## Thank You
+And **thank you!** Your contribution is incredibly important to us.

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,0 +1,16 @@
+{
+	"ImportPath": "github.com/intelsdi-x/snap-plugin-collector-iostat",
+	"GoVersion": "go1.4.2",
+	"Deps": [
+		{
+			"ImportPath": "github.com/intelsdi-x/snap",
+			"Comment": "v0.9.0-beta",
+			"Rev": "e62bd3b4bb1e5044bad152d9a90bf8bbfa881e8f"
+		},
+		{
+			"ImportPath": "github.com/smartystreets/goconvey/convey",
+			"Comment": "1.5.0-386-geb2e83c",
+			"Rev": "eb2e83c1df892d2c9ad5a3c85672da30be585dfd"
+		}
+	]
+}

--- a/Godeps/Readme
+++ b/Godeps/Readme
@@ -1,0 +1,5 @@
+This directory tree is generated automatically by godep.
+
+Please do not edit.
+
+See https://github.com/tools/godep for more information.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+default:
+	$(MAKE) deps
+	$(MAKE) all
+deps:
+	bash -c "godep restore"
+test:
+	bash -c "./scripts/test.sh $(TEST)"
+check:
+	$(MAKE) test
+all:
+	bash -c "./scripts/build.sh $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,317 @@
-# pulse-plugin-collector-iostat
-IOstat Collector Plugin
+<!--
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+	
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Snap Collector Plugin - IOSTAT
+
+This plugin collects CPU statistics and device I/O statistics based on IOSTAT command tool which is available in every distribution of Linux.
+
+Used for monitoring system input/output device loading by observing the time the devices are active in relation to their average transfer rates. 
+
+The intention is that data will be collected, aggregated and fed into graphing and analysis plugin that can be used to change system configuration to better balance the input/output load between physical disks.
+
+Project link: https://github.com/intelsdi-x/snap-plugin-collector-iostat
+
+1. [Getting Started](#getting-started)
+  * [System Requirements](#system-requirements)
+  * [Installation](#installation)
+  * [Configuration and Usage](configuration-and-usage)
+2. [Documentation](#documentation)
+  * [Collected Metrics](#collected-metrics)
+  * [Examples](#examples)
+  * [Roadmap](#roadmap)
+3. [Community Support](#community-support)
+4. [Contributing](#contributing)
+5. [License](#license)
+6. [Acknowledgements](#acknowledgements)
+
+## Getting Started
+
+In order to use this plugin you need "iostat" to be installed on a Linux target host.
+
+### System Requirements
+
+Include:
+
+- systat package 
+- Linux OS
+
+The iostat command-line tool is part of the sysstat package available under the GNU General Public License.
+
+### Installation
+
+a) **install sysstat package** from the official repositories simply use:
+- for Ubuntu, Debian: `sudo apt-get install sysstat`
+- for CentOS, Fedora: `sudo yum install sysstat`
+
+b) **compile plugin snap-plugin-collector-iostat**
+```
+make
+```
+
+### Configuration and Usage
+
+By default, IOSTAT executable binary are searched in the directories named by the PATH environment. 
+Customize IOSTAT's path is also possible by setting environment variable `export SNAP_IOSTAT_PATH=/path/to/iostat/bin`
+
+## Documentation
+
+To learn more about iostat tool visit [http://linux.die.net/man/1/iostat] (http://linux.die.net/man/1/iostat)
+
+### Collected Metrics
+This plugin has the ability to gather the following metrics:
+
+* **CPU statistic**
+
+Metric namespace prefix: /intel/linux/iostat/avg-cpu/
+
+Namespace | Description 
+------------ | -------------
+%user | The percentage of CPU utilization that occurred while executing at the user level (the application usage)
+%nice | The percentage of CPU utilization that occurred while executing at the user level with nice priority
+%system | The percentage of CPU utilization that occurred while executing at the system level (the kernel usage)
+%iowait | The percentage of time that the CPU or CPUs were idle during which the system had an outstanding disk I/O request
+%steal | The percentage of time spent in involuntary wait by the virtual CPU or CPUs while the hypervisor was servicing another virtual processor
+%idle | The percentage of time that the CPU or CPUs were idle and the systems did not have an outstanding disk I/O request
+
+
+
+* **Device statistics**
+
+Metric namespace prefix: /intel/linux/iostat/device/{disk_or_partition}
+
+Name | Description 
+------------ | -------------
+rrqm_per_sec | The number of read requests merged per second queued to the device
+wrqm_per_sec |The number of write requests merged per second queued to the device
+r_per_sec | The number of read requests issued to the device per second
+w_per_sec | The number of write requests issued to the device per second
+rkB_per_sec | The number of kilobytes read from the device per second
+wkB_per_sec | The number of kilobytes written to the device per second
+avgrq-sz | The average size (in sectors) of the requests issued to the device
+avgqu-sz | The average queue length of the requests issued to the device
+await | The average time (milliseconds) for I/O requests issued to the device to be served This includes the time spent by the requests in queue and the time spent servicing them
+r_await | The average time (in milliseconds) for read requests issued to the device to be served which includes the time spent by the requests in queue and the time spent servicing them
+w_await | The average time (in milliseconds) for write requests issued to the device to be served which includes the time spent by the requests in queue and the time spent servicing them
+svctm | The average service time (in milliseconds) for I/O requests issued to the device - Warning! Do not trust this field; it will be removed in a future version of sysstat
+%util | Percentage of CPU time during which I/O requests were issued to the device (bandwidth utilization for the device); device saturation occurs when this values is close to 100%
+
+
+*Notes:*
+
+The total number of read and write requests issued to the device per second equals the number of transaction per second (tps=r_per_sec+w_per_sec).
+
+By default metrics are gathered once per second.
+
+### Examples
+Example running  iostat collector and writing data to a file.
+
+In one terminal window, open the snap daemon:
+```
+$ snapd -l 1 -t 0
+```
+
+In another terminal window, load iostat plugin for collecting:
+```
+$ snapctl plugin load $SNAP_IOSTAT_PLUGIN_DIR/build/rootfs/snap-plugin-collector-iostat
+Plugin loaded
+Name: iostat
+Version: 1
+Type: collector
+Signed: false
+Loaded Time: Tue, 01 Dec 2015 05:19:48 EST
+```
+See available metrics for your system:
+```
+$ snapctl metric list
+```
+
+Load file plugin for publishing:
+```
+$ snapctl plugin load $SNAP_DIR/build/plugin/snap-publisher-file
+Plugin loaded
+Name: file
+Version: 3
+Type: publisher
+Signed: false
+Loaded Time: Tue, 01 Dec 2015 05:21:18 EST
+```
+
+Create a task JSON file (exemplary file in examples/tasks/iostat-file.json):  
+```json
+{
+    "version": 1,
+    "schedule": {
+        "type": "simple",
+        "interval": "1s"
+    },
+    "workflow": {
+        "collect": {
+            "metrics": {
+                "/intel/linux/iostat/avg-cpu/%user": {},
+                "/intel/linux/iostat/avg-cpu/%system": {},
+                "/intel/linux/iostat/avg-cpu/%idle": {},
+				"/intel/linux/iostat/avg-cpu/%iowait": {},
+				"/intel/linux/iostat/avg-cpu/%nice": {},
+				"/intel/linux/iostat/avg-cpu/%steal": {},
+                "/intel/linux/iostat/device/sda1/rrqm_per_sec": {},
+                "/intel/linux/iostat/device/sda1/wrqm_per_sec": {},
+                "/intel/linux/iostat/device/sda1/r_per_sec": {},
+                "/intel/linux/iostat/device/sda1/w_per_sec": {},
+                "/intel/linux/iostat/device/sda1/rkB_per_sec": {},
+                "/intel/linux/iostat/device/sda1/wkB_per_sec": {},
+                "/intel/linux/iostat/device/sda1/%util": {},
+                "/intel/linux/iostat/device/sdb/rrqm_per_sec": {},
+                "/intel/linux/iostat/device/sdb/wrqm_per_sec": {},
+                "/intel/linux/iostat/device/sdb/r_per_sec": {},
+                "/intel/linux/iostat/device/sdb/w_per_sec": {},
+                "/intel/linux/iostat/device/sdb/rkB_per_sec": {},
+                "/intel/linux/iostat/device/sdb/wkB_per_sec": {},
+                "/intel/linux/iostat/device/sdb/%util": {},
+                "/intel/linux/iostat/device/sdb1/rrqm_per_sec": {},
+                "/intel/linux/iostat/device/sdb1/wrqm_per_sec": {},
+                "/intel/linux/iostat/device/sdb1/r_per_sec": {},
+                "/intel/linux/iostat/device/sdb1/w_per_sec": {},
+                "/intel/linux/iostat/device/sdb1/rkB_per_sec": {},
+                "/intel/linux/iostat/device/sdb1/wkB_per_sec": {},
+                "/intel/linux/iostat/device/sdb1/%util": {},
+                "/intel/linux/iostat/device/sdb2/rrqm_per_sec": {},
+                "/intel/linux/iostat/device/sdb2/wrqm_per_sec": {},
+                "/intel/linux/iostat/device/sdb2/r_per_sec": {},
+                "/intel/linux/iostat/device/sdb2/w_per_sec": {},
+                "/intel/linux/iostat/device/sdb2/rkB_per_sec": {},
+                "/intel/linux/iostat/device/sdb2/wkB_per_sec": {},
+                "/intel/linux/iostat/device/sdb2/%util": {},
+                "/intel/linux/iostat/device/ALL/rrqm_per_sec": {},
+                "/intel/linux/iostat/device/ALL/wrqm_per_sec": {},
+                "/intel/linux/iostat/device/ALL/r_per_sec": {},
+                "/intel/linux/iostat/device/ALL/w_per_sec": {},
+                "/intel/linux/iostat/device/ALL/rkB_per_sec": {},
+                "/intel/linux/iostat/device/ALL/wkB_per_sec": {},
+                "/intel/linux/iostat/device/ALL/%util": {}
+            },
+            "config": {
+                "/intel/linux/iostat": {
+                    "user": "root",
+                    "password": "secret"
+                }
+            },
+            "process": null,
+            "publish": [
+                {
+                    "plugin_name": "file",
+                    "plugin_version": 3,
+                    "config": {
+                        "file": "/tmp/published_iostat"
+                    }
+                }
+            ]
+        }
+    }
+}
+```
+
+Create a task:
+```
+$ snapctl task create -t $SNAP_IOSTAT_PLUGIN_DIR/examples/tasks/iostat-file.json
+Using task manifest to create task
+Task created
+ID: 02dd7ff4-8106-47e9-8b86-70067cd0a850
+Name: Task-02dd7ff4-8106-47e9-8b86-70067cd0a850
+State: Running
+```
+
+See sample output from `snapctl task watch <task_id>`
+
+```
+$ snapctl task watch 02dd7ff4-8106-47e9-8b86-70067cd0a850
+
+Watching Task (02dd7ff4-8106-47e9-8b86-70067cd0a850):
+NAMESPACE                                        DATA    TIMESTAMP                               SOURCE
+/intel/linux/iostat/avg-cpu/%idle                97.62   2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/avg-cpu/%iowait              1.13    2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/avg-cpu/%nice                0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/avg-cpu/%steal               0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/avg-cpu/%system              0.5     2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/avg-cpu/%user                0.75    2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/ALL/%util             1.69    2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/ALL/r_per_sec         0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/ALL/rkB_per_sec       0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/ALL/rrqm_per_sec      0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/ALL/w_per_sec         133     2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/ALL/wkB_per_sec       50672   2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/ALL/wrqm_per_sec      326     2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/sda1/%util            0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/sda1/r_per_sec        0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/sda1/rkB_per_sec      0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/sda1/rrqm_per_sec     0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/sda1/w_per_sec        0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/sda1/wkB_per_sec      0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/sda1/wrqm_per_sec     0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/sdb/%util             6.8     2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/sdb/r_per_sec         0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/sdb/rkB_per_sec       0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/sdb/rrqm_per_sec      0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/sdb/w_per_sec         68      2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/sdb/wkB_per_sec       25336   2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/sdb/wrqm_per_sec      163     2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/sdb1/%util            6.7     2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/sdb1/r_per_sec        0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/sdb1/rkB_per_sec      0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/sdb1/rrqm_per_sec     0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/sdb1/w_per_sec        65      2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/sdb1/wkB_per_sec      25336   2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/sdb1/wrqm_per_sec     163     2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/sdb2/%util            0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/sdb2/r_per_sec        0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/sdb2/rkB_per_sec      0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/sdb2/rrqm_per_sec     0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/sdb2/w_per_sec        0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/sdb2/wkB_per_sec      0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/linux/iostat/device/sdb2/wrqm_per_sec     0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+```
+(Keys `ctrl+c` terminate task watcher)
+
+These data are published to file (in this example publishing to /tmp/published_iostat).
+
+### Roadmap
+As we launch this plugin, we have a few items in mind for the next release
+- [ ] Use channels instead "for" loop to execute iostat cmd
+
+If you have a feature request, please add it as an [issue](https://github.com/intelsdi-x/snap-plugin-collector-iostat/issues).
+
+
+## Community Support
+This repository is one of **many** plugins in the **snap framework**: a powerful telemetry agent framework.
+The full project is at https://github.com/intelsdi-x/snap.
+
+## Contributing
+We love contributions! :heart_eyes:
+
+There's more than one way to give back, from examples to blogs to code updates. See our recommended process in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## License
+This is Open Source software released under the Apache 2.0 License. Please see the [LICENSE](LICENSE) file for full license details.
+
+
+## Acknowledgements
+List authors, co-authors and anyone you'd like to mention
+
+* Author: [Izabella Raulin](https://github.com/IzabellaRaulin)
+
+**Thank you!** Your contribution is incredibly important to us.
+

--- a/examples/tasks/iostat-file.json
+++ b/examples/tasks/iostat-file.json
@@ -1,0 +1,70 @@
+{
+    "version": 1,
+    "schedule": {
+        "type": "simple",
+        "interval": "1s"
+    },
+    "workflow": {
+        "collect": {
+            "metrics": {
+                "/intel/linux/iostat/avg-cpu/%user": {},
+                "/intel/linux/iostat/avg-cpu/%system": {},
+                "/intel/linux/iostat/avg-cpu/%idle": {},
+                "/intel/linux/iostat/avg-cpu/%iowait": {},
+                "/intel/linux/iostat/avg-cpu/%nice": {},
+                "/intel/linux/iostat/avg-cpu/%steal": {},
+                "/intel/linux/iostat/device/sda1/rrqm_per_sec": {},
+                "/intel/linux/iostat/device/sda1/wrqm_per_sec": {},
+                "/intel/linux/iostat/device/sda1/r_per_sec": {},
+                "/intel/linux/iostat/device/sda1/w_per_sec": {},
+                "/intel/linux/iostat/device/sda1/rkB_per_sec": {},
+                "/intel/linux/iostat/device/sda1/wkB_per_sec": {},
+                "/intel/linux/iostat/device/sda1/%util": {},
+                "/intel/linux/iostat/device/sdb/rrqm_per_sec": {},
+                "/intel/linux/iostat/device/sdb/wrqm_per_sec": {},
+                "/intel/linux/iostat/device/sdb/r_per_sec": {},
+                "/intel/linux/iostat/device/sdb/w_per_sec": {},
+                "/intel/linux/iostat/device/sdb/rkB_per_sec": {},
+                "/intel/linux/iostat/device/sdb/wkB_per_sec": {},
+                "/intel/linux/iostat/device/sdb/%util": {},
+                "/intel/linux/iostat/device/sdb1/rrqm_per_sec": {},
+                "/intel/linux/iostat/device/sdb1/wrqm_per_sec": {},
+                "/intel/linux/iostat/device/sdb1/r_per_sec": {},
+                "/intel/linux/iostat/device/sdb1/w_per_sec": {},
+                "/intel/linux/iostat/device/sdb1/rkB_per_sec": {},
+                "/intel/linux/iostat/device/sdb1/wkB_per_sec": {},
+                "/intel/linux/iostat/device/sdb1/%util": {},
+                "/intel/linux/iostat/device/sdb2/rrqm_per_sec": {},
+                "/intel/linux/iostat/device/sdb2/wrqm_per_sec": {},
+                "/intel/linux/iostat/device/sdb2/r_per_sec": {},
+                "/intel/linux/iostat/device/sdb2/w_per_sec": {},
+                "/intel/linux/iostat/device/sdb2/rkB_per_sec": {},
+                "/intel/linux/iostat/device/sdb2/wkB_per_sec": {},
+                "/intel/linux/iostat/device/sdb2/%util": {},
+                "/intel/linux/iostat/device/ALL/rrqm_per_sec": {},
+                "/intel/linux/iostat/device/ALL/wrqm_per_sec": {},
+                "/intel/linux/iostat/device/ALL/r_per_sec": {},
+                "/intel/linux/iostat/device/ALL/w_per_sec": {},
+                "/intel/linux/iostat/device/ALL/rkB_per_sec": {},
+                "/intel/linux/iostat/device/ALL/wkB_per_sec": {},
+                "/intel/linux/iostat/device/ALL/%util": {}
+            },
+            "config": {
+                "/intel/linux/iostat": {
+                    "user": "root",
+                    "password": "secret"
+                }
+            },
+            "process": null,
+            "publish": [
+                {
+                    "plugin_name": "file",
+                    "plugin_version": 3,
+                    "config": {
+                        "file": "/tmp/published_iostat"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/iostat/iostat.go
+++ b/iostat/iostat.go
@@ -1,0 +1,328 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package iostat
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/intelsdi-x/snap/control/plugin"
+	"github.com/intelsdi-x/snap/control/plugin/cpolicy"
+)
+
+const (
+	// Name of plugin
+	Name = "iostat"
+	// Version of plugin
+	Version = 1
+	// Type of plugin
+	Type = plugin.CollectorPluginType
+
+	ns_vendor = "intel"
+	ns_class  = "linux"
+	ns_type   = "iostat"
+
+	defaultTimeout              = 2 * time.Second
+	defaultEmptyTokenAcceptance = 5
+)
+
+//interfaces needed for mocking command output in iostat_test.go
+type Command interface {
+	getEnv(string) string
+	lookPath(string) (string, error)
+	execCommand(name string, arg ...string) *exec.Cmd
+}
+
+// IOSTAT
+type IOSTAT struct {
+	keys      []string
+	data      map[string]interface{}
+	timestamp time.Time
+	mutex     *sync.RWMutex
+	cmdCall   Command
+}
+
+type RealCmdCall struct{}
+
+// execCommand returns the Cmd struct to execute the named program with the given arguments
+func (c *RealCmdCall) execCommand(name string, arg ...string) *exec.Cmd {
+	return exec.Command(name, arg...)
+}
+
+func (c *RealCmdCall) getEnv(key string) string {
+	return os.Getenv(key)
+}
+
+func (c *RealCmdCall) lookPath(file string) (string, error) {
+	return exec.LookPath(file)
+}
+
+// CollectMetrics returns metrics from iostat
+func (iostat *IOSTAT) CollectMetrics(mts []plugin.PluginMetricType) ([]plugin.PluginMetricType, error) {
+	metrics := make([]plugin.PluginMetricType, len(mts))
+	iostat.mutex.RLock()
+	defer iostat.mutex.RUnlock()
+	hostname, _ := os.Hostname()
+	for i, m := range mts {
+		if v, ok := iostat.data[joinNamespace(m.Namespace())]; ok {
+			metrics[i] = plugin.PluginMetricType{
+				Namespace_: m.Namespace(),
+				Data_:      v,
+				Source_:    hostname,
+				Timestamp_: iostat.timestamp,
+			}
+		}
+	}
+	return metrics, nil
+}
+
+// GetMetricTypes returns the metric types exposed by iostat
+func (iostat *IOSTAT) GetMetricTypes(_ plugin.PluginConfigType) ([]plugin.PluginMetricType, error) {
+	mts := make([]plugin.PluginMetricType, len(iostat.keys))
+	iostat.mutex.RLock()
+	defer iostat.mutex.RUnlock()
+	for i, k := range iostat.keys {
+		mts[i] = plugin.PluginMetricType{Namespace_: strings.Split(strings.TrimPrefix(k, "/"), "/")}
+	}
+	return mts, nil
+}
+
+//GetConfigPolicy
+func (iostat *IOSTAT) GetConfigPolicy() (*cpolicy.ConfigPolicy, error) {
+	c := cpolicy.New()
+	return c, nil
+}
+
+// Init initializes iostat plugin
+func (iostat *IOSTAT) init() (*IOSTAT, error) {
+	var cmd *exec.Cmd
+
+	/////////////////////////////////////////////////////////////////////////////////////////
+	// 	IOstat command with interval 1 and options:
+	// 		-c	 	display the CPU utilization report
+	// 		-d	 	display the device utilization report
+	// 		-p	 	display statistics for block devices and all their partitions
+	// 		-g ALL	display statistics for a group of devices
+	// 		-x		display extended statistics
+	// 		-k		display bandwidth statistics in kilobytes per second
+	// 		-t		print the time for each report displayed
+	////////////////////////////////////////////////////////////////////////////////////////
+
+	args := []string{"-c", "-d", "-p", "-g", "ALL", "-x", "-k", "-t", "1"}
+
+	if path := iostat.cmdCall.getEnv("SNAP_IOSTAT_PATH"); path != "" {
+		cmd = iostat.cmdCall.execCommand(filepath.Join(path, "iostat"), args...)
+	} else {
+		c, err := iostat.cmdCall.lookPath("iostat")
+		if err != nil {
+			fmt.Fprint(os.Stderr, "Unable to find iostat (\"systat\" package).  Ensure it's in your path or set SNAP_IOSTAT_PATH.")
+			panic(err)
+		}
+		cmd = iostat.cmdCall.execCommand(c, args...)
+	}
+	cmdReader, err := cmd.StdoutPipe()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error creating StdoutPipe", err)
+		return nil, err
+	}
+
+	// read the data from stdout
+	scanner := bufio.NewScanner(cmdReader)
+	title := true
+	emptyTokens := 0
+
+	go func() {
+		first := true
+		var statType string
+		var statSubType string
+		var statNames []string
+		var keys []string
+		var data []string
+		var key string
+
+		for scanner.Scan() {
+			line := removeEmptyStr(strings.Split(strings.TrimSpace(scanner.Text()), " "))
+			if len(line) == 0 {
+				// slice "line" is empty
+				emptyTokens++
+				if emptyTokens > defaultEmptyTokenAcceptance {
+					// more empty slice than acceptance level means error occurs, break the loop
+					break
+				}
+				continue
+			}
+			emptyTokens = 0
+
+			if title {
+				// skip the title line
+				title = false
+				continue
+			}
+			if first {
+				//next interval separated by a newline
+				first = false
+				keys = []string{}
+				data = []string{}
+
+				/////////////////////////////////////////////////////////////////////////////
+				// HERE: 	possible parsing output to get timestamp delivered by iostat
+				//			the default format: "MM/DD/YYYY HH:MM:SS AM/PM"
+				/////////////////////////////////////////////////////////////////////////////
+
+				// getting timestamp as current local time
+				// in format: "YYYY-MM-DD HH:MM:SS.fffffffff +/-HHMM TZ
+				iostat.timestamp = time.Now()
+				continue
+			}
+
+			if strings.HasSuffix(line[0], ":") {
+				if len(line) > 1 {
+					statType = strings.ToLower(strings.TrimSuffix(line[0], ":"))
+					statNames = replaceByPerSec(line[1:])
+					continue
+				}
+			}
+
+			if len(statNames) == 0 || len(statType) == 0 {
+				fmt.Fprintf(os.Stderr, "Invalid format of iostat output data\n")
+				break
+			}
+			if len(line) > len(statNames) {
+				// subType is defined
+				statSubType = line[0]
+				line = line[1:]
+			} else {
+				statSubType = ""
+			}
+
+			if len(line) == len(statNames) && len(statNames) != 0 {
+				for i, statName := range statNames {
+
+					if statSubType != "" {
+						key = statType + "/" + statSubType + "/" + statName
+					} else {
+						key = statType + "/" + statName
+					}
+
+					keys = append(keys, key)
+					data = append(data, line[i])
+				}
+			}
+
+			if strings.ToLower(statSubType) == "all" {
+				// all available metrics keys collected
+				first = true // for next scan skip first line
+
+				if len(iostat.keys) == 0 {
+
+					if len(keys) == 0 {
+						panic(errors.New("Error getting iostat metrics namespace"))
+					}
+
+					iostat.mutex.Lock()
+					iostat.keys = make([]string, len(keys))
+					for i, k := range keys {
+						iostat.keys[i] = joinNamespace(createNamespace(k))
+					}
+					iostat.mutex.Unlock()
+				}
+
+				if len(data) != len(iostat.keys) {
+					panic(errors.New("Invalid parsing iostat output"))
+				}
+
+				iostat.mutex.Lock()
+				for i, d := range data {
+					v, err := strconv.ParseFloat(strings.TrimSpace(d), 64)
+					if err == nil {
+						iostat.data[iostat.keys[i]] = v
+					} else {
+						fmt.Fprintln(os.Stderr, "Invalid metric value", err)
+						iostat.data[iostat.keys[i]] = nil
+					}
+
+				}
+				iostat.mutex.Unlock()
+			}
+		} // end of scanning
+	}() // end of go routine
+
+	err = cmd.Start()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error starting iostat", err)
+		return nil, fmt.Errorf(fmt.Sprintf("Error starting iostat command, err=%+v", err))
+	}
+	// we need to wait until we have our metric types
+	st := time.Now()
+	for {
+		iostat.mutex.RLock()
+		c := len(iostat.keys)
+		iostat.mutex.RUnlock()
+		if c > 0 {
+			break
+		}
+		if time.Since(st) > defaultTimeout {
+			return nil, fmt.Errorf("Timed out waiting for metrics from iostat")
+		}
+	}
+	return iostat, nil
+}
+
+func joinNamespace(ns []string) string {
+	return "/" + strings.Join(ns, "/")
+}
+
+// createNamespace returns namespace slice of strings composed from: vendor, class, type and ceph-daemon name
+func createNamespace(name string) []string {
+	return []string{ns_vendor, ns_class, ns_type, name}
+}
+
+// removeEmptyStr removes empty strings from slice
+func removeEmptyStr(slice []string) []string {
+	var result []string
+	for _, str := range slice {
+		if str != "" {
+			result = append(result, str)
+		}
+	}
+	return result
+}
+
+// replacePerSec turns "/s" into "_per_sec"
+func replaceByPerSec(slice []string) []string {
+	for i, str := range slice {
+		slice[i] = strings.Replace(str, "/s", "_per_sec", 1)
+	}
+	return slice
+}
+
+// New returns snap-plugin-collector-iostat instance
+func New() (*IOSTAT, error) {
+	iostat := &IOSTAT{mutex: &sync.RWMutex{}, data: map[string]interface{}{}, cmdCall: &RealCmdCall{}}
+	return iostat.init()
+}

--- a/iostat/iostat_test.go
+++ b/iostat/iostat_test.go
@@ -1,0 +1,426 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package iostat
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/intelsdi-x/snap/control/plugin"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+type Mock struct {
+	key   string
+	value float64
+}
+
+var ns_prefix = []string{ns_vendor, ns_class, ns_type}
+
+var mockKV = []Mock{
+	{"/intel/linux/iostat/avg-cpu/%user", 0.50},
+	{"/intel/linux/iostat/avg-cpu/%nice", 0.00},
+	{"/intel/linux/iostat/avg-cpu/%system", 0.13},
+	{"/intel/linux/iostat/avg-cpu/%iowait", 0.00},
+	{"/intel/linux/iostat/avg-cpu/%steal", 0.00},
+	{"/intel/linux/iostat/avg-cpu/%idle", 99.37},
+	{"/intel/linux/iostat/device/sda/rrqm_per_sec", 0.00},
+	{"/intel/linux/iostat/device/sdb/wrqm_per_sec", 0.33},
+	{"/intel/linux/iostat/device/sda1/r_per_sec", 0.00},
+	{"/intel/linux/iostat/device/sdb1/w_per_sec", 0.08},
+	{"/intel/linux/iostat/device/sda2/rkB_per_sec", 0.00},
+	{"/intel/linux/iostat/device/sdb2/wkB_per_sec", 4.55},
+	{"/intel/linux/iostat/device/sda3/avgrq-sz", 8.00},
+	{"/intel/linux/iostat/device/sda4/avgqu-sz", 0.00},
+	{"/intel/linux/iostat/device/sdb/await", 1.83},
+	{"/intel/linux/iostat/device/sdb/r_await", 0.94},
+	{"/intel/linux/iostat/device/sdb/w_await", 2.00},
+	{"/intel/linux/iostat/device/sdb/svctm", 0.06},
+	{"/intel/linux/iostat/device/sdb/%util", 0.00},
+	{"/intel/linux/iostat/device/ALL/rrqm_per_sec", 0.05},
+	{"/intel/linux/iostat/device/ALL/wkB_per_sec", 30.68},
+}
+
+var mockCmdOut = `Linux 3.10.0-229.11.1.el7.x86_64 (gklab-108-166) 0/26/2015      _x86_64_        (8 CPU)
+				
+			10/26/2015 06:36:57 AM
+			avg-cpu:  %user   %nice %system %iowait  %steal   %idle
+			           0.50    0.00    0.13    0.00    0.00   99.37
+			
+			Device:         rrqm/s   wrqm/s     r/s     w/s    rkB/s    wkB/s avgrq-sz avgqu-sz   await r_await w_await  svctm  %util
+			sda               0.00     0.00    0.00    0.00     0.01     0.00     8.06     0.00    0.10    0.10    0.00   0.04   0.00
+			sda1              0.00     0.00    0.00    0.00     0.00     0.00     8.19     0.00    0.12    0.12    0.00   0.12   0.00
+			sda2              0.00     0.00    0.00    0.00     0.00     0.00     7.80     0.00    0.08    0.08    0.00   0.08   0.00
+			sda3              0.00     0.00    0.00    0.00     0.00     0.00     8.00     0.00    0.12    0.12    0.00   0.12   0.00
+			sda4              0.00     0.00    0.00    0.00     0.00     0.00     8.00     0.00    0.11    0.11    0.00   0.11   0.00
+			sdb               0.02     0.33    0.13    0.64     2.08    15.34    45.70     0.00    1.83    0.94    2.00   0.06   0.00
+			sdb1              0.00     0.07    0.04    0.08     0.26    10.79   185.22     0.00    9.81    0.23   14.21   0.25   0.00
+			sdb2              0.02     0.26    0.09    0.55     1.81     4.55    19.87     0.00    0.34    1.24    0.20   0.03   0.00
+			 ALL              0.05     0.66    0.26    1.27     4.17    30.68    45.65     0.00    1.82    0.92    2.00   0.06   0.00
+				
+		`
+
+var mockMts = []plugin.PluginMetricType{
+	plugin.PluginMetricType{
+		Namespace_: []string{"intel", "linux", "iostat", "device", "sda", "%util"},
+	},
+	plugin.PluginMetricType{
+		Namespace_: []string{"intel", "linux", "iostat", "device", "sdb", "%util"},
+	},
+	plugin.PluginMetricType{
+		Namespace_: []string{"intel", "linux", "iostat", "device", "ALL", "%util"},
+	},
+
+	plugin.PluginMetricType{
+		Namespace_: []string{"intel", "linux", "iostat", "device", "sda", "sda1", "rkB_per_sec"},
+	},
+
+	plugin.PluginMetricType{
+		Namespace_: []string{"intel", "linux", "iostat", "device", "sda", "sdb1", "w_per_sec"},
+	},
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//	***					MOCKING FUNCTIONS								***	//
+// 	***		mocking: exec.Command, os.Getenv, exec.LookPath				***	//
+//////////////////////////////////////////////////////////////////////////////
+
+type MockCmdCall struct {
+	getEnvOut   struct{ env string }
+	lookPathOut struct {
+		path string
+		err  error
+	}
+	execCommandOut struct {
+		name string
+		args []string
+	}
+}
+
+func (m *MockCmdCall) getEnv(key string) string {
+	return m.getEnvOut.env
+}
+
+func (m *MockCmdCall) lookPath(file string) (string, error) {
+	return m.lookPathOut.path, m.lookPathOut.err
+}
+
+func (m *MockCmdCall) execCommand(name string, arg ...string) *exec.Cmd {
+	return exec.Command(m.execCommandOut.name, m.execCommandOut.args...)
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//	***						TESTS										***	//
+//////////////////////////////////////////////////////////////////////////////
+
+func TestGetMetricTypes(t *testing.T) {
+	var conf plugin.PluginConfigType
+	iostat := &IOSTAT{mutex: &sync.RWMutex{}, data: map[string]interface{}{},
+		cmdCall: &MockCmdCall{}}
+	iostat.keys = make([]string, len(mockMts))
+
+	Convey("no metrics available", t, func() {
+		So(func() { iostat.GetMetricTypes(conf) }, ShouldNotPanic)
+		result, err := iostat.GetMetricTypes(conf)
+		So(len(result), ShouldEqual, len(iostat.keys))
+		So(err, ShouldBeNil)
+
+		for _, r := range result {
+			So(r.Namespace(), ShouldResemble, []string{""})
+			So(r.Data(), ShouldBeNil)
+			So(r.Source(), ShouldBeEmpty)
+		}
+	})
+
+	// mocking iostat keys
+	for i, m := range mockMts {
+		iostat.keys[i] = joinNamespace(m.Namespace())
+	}
+
+	Convey("getMetricsTypes returns no error", t, func() {
+		//		var conf plugin.PluginConfigType
+		So(func() { iostat.GetMetricTypes(conf) }, ShouldNotPanic)
+		result, err := iostat.GetMetricTypes(conf)
+		So(len(result), ShouldEqual, len(iostat.keys))
+		So(err, ShouldBeNil)
+		for i, r := range result {
+			So(r.Namespace(), ShouldResemble, strings.Split(strings.TrimPrefix(iostat.keys[i], "/"), "/"))
+		}
+	})
+}
+
+func TestCollectMetrics(t *testing.T) {
+	iostat := &IOSTAT{mutex: &sync.RWMutex{}, data: map[string]interface{}{}, cmdCall: &MockCmdCall{}}
+
+	Convey("no iostat metric available", t, func() {
+		So(func() { iostat.CollectMetrics(mockMts) }, ShouldNotPanic)
+		result, err := iostat.CollectMetrics(mockMts)
+		So(len(result), ShouldEqual, len(mockMts))
+		So(err, ShouldBeNil)
+
+		for _, r := range result {
+			So(r.Namespace(), ShouldBeEmpty)
+			So(r.Data(), ShouldBeNil)
+			So(r.Source(), ShouldBeEmpty)
+		}
+	})
+
+	Convey("invalid metric namespace", t, func() {
+		iostat.keys = []string{"intel/linux/iostat/device/sda/%wrong"}
+		iostat.data[iostat.keys[0]] = 1
+
+		So(func() { iostat.CollectMetrics(mockMts) }, ShouldNotPanic)
+		result, err := iostat.CollectMetrics(mockMts)
+		So(len(result), ShouldEqual, len(mockMts))
+		So(err, ShouldBeNil)
+
+		for _, r := range result {
+			So(r.Namespace(), ShouldBeEmpty)
+			So(r.Data(), ShouldBeNil)
+			So(r.Source(), ShouldBeEmpty)
+		}
+	})
+
+	Convey("collect metrics with no errors", t, func() {
+		tstamp := time.Now()
+		hostname, _ := os.Hostname()
+		iostat.keys = make([]string, len(mockMts))
+		iostat.timestamp = tstamp
+
+		for i, m := range mockMts {
+			iostat.keys[i] = joinNamespace(m.Namespace())
+			iostat.data[iostat.keys[i]] = float32(i) * 1.0
+
+		}
+
+		So(func() { iostat.CollectMetrics(mockMts) }, ShouldNotPanic)
+		result, err := iostat.CollectMetrics(mockMts)
+		So(len(result), ShouldEqual, len(mockMts))
+		So(err, ShouldBeNil)
+
+		for _, r := range result {
+			So(iostat.keys, ShouldContain, joinNamespace(r.Namespace()))
+			So(r.Timestamp(), ShouldResemble, tstamp)
+			So(r.Source(), ShouldEqual, hostname)
+			So(r.Data(), ShouldEqual, iostat.data[joinNamespace(r.Namespace())])
+		}
+	})
+}
+
+func TestInit(t *testing.T) {
+	Convey("successful init iostat plugin", t, func() {
+		mcc := &MockCmdCall{}
+		mcc.getEnvOut.env = "path/to/iostat/bin"
+		mcc.execCommandOut.name = "echo"
+		mcc.execCommandOut.args = []string{mockCmdOut}
+
+		iostat := &IOSTAT{mutex: &sync.RWMutex{}, data: map[string]interface{}{}, cmdCall: mcc}
+		So(func() { iostat.init() }, ShouldNotPanic)
+		result, err := iostat.init()
+		So(result, ShouldNotBeNil)
+		So(len(result.keys), ShouldEqual, len(result.data))
+		So(err, ShouldBeNil)
+
+		for _, m := range mockKV {
+			So(result.keys, ShouldContain, m.key)
+			So(result.data[m.key], ShouldNotBeNil)
+			So(result.data[m.key], ShouldEqual, m.value)
+		}
+	})
+}
+
+func TestInvalidInit(t *testing.T) {
+	Convey("executable file not found in $PATH", t, func() {
+		mcc := &MockCmdCall{}
+		mcc.getEnvOut.env = ""
+		mcc.lookPathOut.path = ""
+		mcc.lookPathOut.err = errors.New("executable file not found in $PATH")
+
+		iostat := &IOSTAT{mutex: &sync.RWMutex{}, data: map[string]interface{}{}, cmdCall: mcc}
+		So(func() { iostat.init() }, ShouldPanic)
+	})
+
+	Convey("invalid command - error starting of execution", t, func() {
+		mcc := &MockCmdCall{}
+		mcc.lookPathOut.path = "path/to/iostat/bin"
+		mcc.lookPathOut.err = nil
+		mcc.execCommandOut.name = ""
+		mcc.execCommandOut.args = []string{}
+
+		iostat := &IOSTAT{mutex: &sync.RWMutex{}, data: map[string]interface{}{}, cmdCall: mcc}
+		So(func() { iostat.init() }, ShouldNotPanic)
+		result, err := iostat.init()
+		So(result, ShouldBeNil)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("output is null, err: timeout for waiting for metrics", t, func() {
+		mcc := &MockCmdCall{}
+		mcc.getEnvOut.env = "path/to/iostat/bin"
+		mcc.execCommandOut.name = "echo"
+		mcc.execCommandOut.args = []string{""}
+
+		iostat := &IOSTAT{mutex: &sync.RWMutex{}, data: map[string]interface{}{}, cmdCall: mcc}
+		So(func() { iostat.init() }, ShouldNotPanic)
+		result, err := iostat.init()
+		So(result, ShouldBeNil)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("invalid output, err: timeout for waiting for metrics ", t, func() {
+		mcc := &MockCmdCall{}
+		mcc.getEnvOut.env = "path/to/iostat/bin"
+		mcc.execCommandOut.name = "echo"
+		mcc.execCommandOut.args = []string{"a", "b"}
+
+		iostat := &IOSTAT{mutex: &sync.RWMutex{}, data: map[string]interface{}{}, cmdCall: mcc}
+		So(func() { iostat.init() }, ShouldNotPanic)
+		result, err := iostat.init()
+		So(result, ShouldBeNil)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("empty tokens > defaultEmptyTokenAcceptance, err: timeout for waiting for metrics", t, func() {
+		mcc := &MockCmdCall{}
+		mcc.getEnvOut.env = "path/to/iostat/bin"
+		mcc.execCommandOut.name = "echo"
+
+		for i := 0; i <= defaultEmptyTokenAcceptance; i++ {
+			mcc.execCommandOut.args = append(mcc.execCommandOut.args, fmt.Sprint("\n"))
+		}
+
+		iostat := &IOSTAT{mutex: &sync.RWMutex{}, data: map[string]interface{}{}, cmdCall: mcc}
+		So(func() { iostat.init() }, ShouldNotPanic)
+		result, err := iostat.init()
+		So(result, ShouldBeNil)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("incorrect last section, err: timeout for waiting for metrics", t, func() {
+		mcc := &MockCmdCall{}
+		mcc.getEnvOut.env = "path/to/iostat/bin"
+		mcc.execCommandOut.name = "echo"
+
+		// command output where "ALL" section does not occure
+		mcc.execCommandOut.args = []string{strings.Replace(mockCmdOut, "ALL", "", 1)}
+
+		iostat := &IOSTAT{mutex: &sync.RWMutex{}, data: map[string]interface{}{}, cmdCall: mcc}
+		So(func() { iostat.init() }, ShouldNotPanic)
+		result, err := iostat.init()
+		So(result, ShouldBeNil)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("no statType defined, err: invalid format of iostat output data", t, func() {
+		mcc := &MockCmdCall{}
+		mcc.getEnvOut.env = "path/to/iostat/bin"
+		mcc.execCommandOut.name = "echo"
+
+		//command output where cannot recognize statType (removed ":")
+		mcc.execCommandOut.args = []string{strings.Replace(mockCmdOut, "avg-cpu:", "avg-cpu", 1)}
+
+		iostat := &IOSTAT{mutex: &sync.RWMutex{}, data: map[string]interface{}{}, cmdCall: mcc}
+		So(func() { iostat.init() }, ShouldNotPanic)
+		result, err := iostat.init()
+		So(result, ShouldBeNil)
+		So(err, ShouldNotBeNil)
+
+	})
+
+	Convey("less metric's values than expected for avg-cpu stats", t, func() {
+		mcc := &MockCmdCall{}
+		mcc.getEnvOut.env = "path/to/iostat/bin"
+		mcc.execCommandOut.name = "echo"
+
+		// command output where for avg-cpu stats is less values than expected like:
+		// avg-cpu:  %user   %nice %system %iowait  %steal   %idle
+		//	          0.50    0.13    0.00    0.00   99.37
+
+		mcc.execCommandOut.args = []string{strings.Replace(mockCmdOut, "0.00", "", 1)}
+		iostat := &IOSTAT{mutex: &sync.RWMutex{}, data: map[string]interface{}{}, cmdCall: mcc}
+		So(func() { iostat.init() }, ShouldNotPanic)
+		result, err := iostat.init()
+		So(result, ShouldNotBeEmpty)
+		So(err, ShouldBeNil)
+
+		for _, key := range result.keys {
+			// invalid format for avg-cpu statistics, avg-cpu metrics were omitted
+			So(key, ShouldNotContainSubstring, "avg-cpu")
+			So(key, ShouldContainSubstring, "device")
+		}
+
+	})
+
+	Convey("more values of metrics than expected for device stats", t, func() {
+		mcc := &MockCmdCall{}
+		mcc.getEnvOut.env = "path/to/iostat/bin"
+		mcc.execCommandOut.name = "echo"
+
+		// command output where for sda1 stats is more values than expected like:
+		//Device:         rrqm/s   wrqm/s     r/s     w/s    rkB/s    wkB/s avgrq-sz avgqu-sz   await r_await w_await  svctm  %util
+		//	sda1           1.11     0.00     0.00    0.00    0.00     0.00     0.00     8.19     0.00    0.12    0.12    0.00   0.12   0.00
+
+		mcc.execCommandOut.args = []string{strings.Replace(mockCmdOut, "sda1 ", "sda 1.11 ", 1)}
+		iostat := &IOSTAT{mutex: &sync.RWMutex{}, data: map[string]interface{}{}, cmdCall: mcc}
+		So(func() { iostat.init() }, ShouldNotPanic)
+		result, err := iostat.init()
+		So(result, ShouldNotBeEmpty)
+		So(err, ShouldBeNil)
+
+		for _, key := range result.keys {
+			// invalid format of sda1 stats, device metrics omitted
+			So(key, ShouldNotContainSubstring, "device/sda1/")
+		}
+	})
+
+	Convey("invalid values of metrics, err: strconv.ParseFloat invalid syntax", t, func() {
+		mcc := &MockCmdCall{}
+		mcc.getEnvOut.env = "path/to/iostat/bin"
+		mcc.execCommandOut.name = "echo"
+
+		// command output where for sda stats value is not floating-point number
+		mcc.execCommandOut.args = []string{
+			`Linux 3.10.0-229.11.1.el7.x86_64 (gklab-108-166) 0/26/2015      _x86_64_        (8 CPU)
+				
+			10/26/2015 06:36:57 AM
+			Device:         rrqm/s   wrqm/s     r/s        
+			sda              err   	  n/a    	null    
+			ALL              none     nil    	zero   
+				
+			`,
+		}
+
+		iostat := &IOSTAT{mutex: &sync.RWMutex{}, data: map[string]interface{}{}, cmdCall: mcc}
+		So(func() { iostat.init() }, ShouldNotPanic)
+		result, err := iostat.init()
+		So(result, ShouldNotBeEmpty)
+		So(err, ShouldBeNil)
+
+		for _, key := range result.keys {
+			So(result.data[key], ShouldBeNil)
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,43 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+
+	// Import the snap plugin library
+	"github.com/intelsdi-x/snap-plugin-collector-iostat/iostat"
+
+	// Import our collector plugin implementation
+	"github.com/intelsdi-x/snap/control/plugin"
+)
+
+// plugin bootstrap
+func main() {
+	p, err := iostat.New()
+	if err != nil {
+		panic(err)
+	}
+	plugin.Start(
+		plugin.NewPluginMeta(iostat.Name, iostat.Version, iostat.Type, []string{}, []string{plugin.SnapGOBContentType}, plugin.ConcurrencyCount(1)),
+		p,
+		os.Args[1],
+	)
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,40 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestMain(t *testing.T) {
+	if _, err := exec.LookPath("iostat"); err == nil {
+		Convey("ensure plugin loads and responds", t, func() {
+			os.Args = []string{"", "{\"NoDaemon\": true}"}
+			So(func() { main() }, ShouldNotPanic)
+		})
+	} else {
+		fmt.Println("Do not find iostat executable. Test skipped")
+	}
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+
+GITVERSION=`git describe --always`
+SOURCEDIR=$1
+BUILDDIR=$SOURCEDIR/build
+PLUGIN=`echo $SOURCEDIR | grep -oh "snap-.*"`
+ROOTFS=$BUILDDIR/rootfs
+BUILDCMD='go build -a -ldflags "-w"'
+
+echo
+echo "****  Snap Plugin Build  ****"
+echo
+
+# Disable CGO for builds
+export CGO_ENABLED=0
+
+# Clean build bin dir
+rm -rf $ROOTFS/*
+
+# Make dir
+mkdir -p $ROOTFS
+
+# Build plugin
+echo "Source Dir = $SOURCEDIR"
+echo "Building Snap Plugin: $PLUGIN"
+$BUILDCMD -o $ROOTFS/$PLUGIN
+

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,84 @@
+#!/bin/bash -e
+# The script does automatic checking on a Go package and its sub-packages, including:
+# 1. gofmt         (http://golang.org/cmd/gofmt/)
+# 2. goimports     (https://github.com/bradfitz/goimports)
+# 3. golint        (https://github.com/golang/lint)
+# 4. go vet        (http://golang.org/cmd/vet)
+# 5. race detector (http://blog.golang.org/race-detector)
+# 6. test coverage (http://blog.golang.org/cover)
+
+# Capture what test we should run
+TEST_SUITE=$1
+
+if [[ $TEST_SUITE == "unit" ]]; then
+	go get github.com/axw/gocov/gocov
+	go get github.com/mattn/goveralls
+	go get -u github.com/golang/lint/golint
+	go get golang.org/x/tools/cmd/vet
+	go get golang.org/x/tools/cmd/goimports
+	go get github.com/smartystreets/goconvey/convey
+	go get golang.org/x/tools/cmd/cover
+	
+	COVERALLS_TOKEN=t47LG6BQsfLwb9WxB56hXUezvwpED6D11
+	TEST_DIRS="main.go iostat/"
+	VET_DIRS=". ./iostat/..."
+
+	set -e
+
+	# Automatic checks
+	echo "gofmt"
+	test -z "$(gofmt -l -d $TEST_DIRS | tee /dev/stderr)"
+
+	echo "goimports"
+	test -z "$(goimports -l -d $TEST_DIRS | tee /dev/stderr)"
+
+	# Useful but should not fail on link per: https://github.com/golang/lint
+	# "The suggestions made by golint are exactly that: suggestions. Golint is not perfect,
+	# and has both false positives and false negatives. Do not treat its output as a gold standard.
+	# We will not be adding pragmas or other knobs to suppress specific warnings, so do not expect
+	# or require code to be completely "lint-free". In short, this tool is not, and will never be,
+	# trustworthy enough for its suggestions to be enforced automatically, for example as part of
+	# a build process"
+	# echo "golint"
+	# golint ./...
+
+	echo "go vet"
+	go vet $VET_DIRS
+	# go test -race ./... - Lets disable for now
+ 
+	# Run test coverage on each subdirectories and merge the coverage profile.
+	echo "mode: count" > profile.cov
+ 
+	# Standard go tooling behavior is to ignore dirs with leading underscors
+	for dir in $(find . -maxdepth 10 -not -path './.git*' -not -path '*/_*' -not -path './examples/*' -not -path './scripts/*' -not -path './build/*' -not -path './Godeps/*' -type d);
+	do
+		if ls $dir/*.go &> /dev/null; then
+	    		go test --tags=unit -covermode=count -coverprofile=$dir/profile.tmp $dir
+	    		if [ -f $dir/profile.tmp ]
+	    		then
+	        		cat $dir/profile.tmp | tail -n +2 >> profile.cov
+	        		rm $dir/profile.tmp
+	    		fi
+		fi
+	done
+ 
+	go tool cover -func profile.cov
+ 
+	# Disabled Coveralls.io for now
+	# To submit the test coverage result to coveralls.io,
+	# use goveralls (https://github.com/mattn/goveralls)
+	# goveralls -coverprofile=profile.cov -service=travis-ci -repotoken t47LG6BQsfLwb9WxB56hXUezvwpED6D11
+	#
+	# If running inside Travis we update coveralls. We don't want his happening on Macs
+	# if [ "$TRAVIS" == "true" ]
+	# then
+	#     n=1
+	#     until [ $n -ge 6 ]
+	#     do
+	#         echo "posting to coveralls attempt $n of 5"
+	#         goveralls -v -coverprofile=profile.cov -service travis.ci -repotoken $COVERALLS_TOKEN && break
+	#         n=$[$n+1]
+	#         sleep 30
+	#     done
+	# fi
+fi


### PR DESCRIPTION
## snap IOSTAT Collector Plugin
# Description

Collect CPU statistics and device I/O statistics by IOSTAT command tool (available in every distribution of Linux).

Used for monitoring system input/output device loading by observing the time the devices are active in relation to their average transfer rates. 

The intention is that data will be collected, aggregated and fed into graphing and analysis plugin that can be used to change system configuration to better balance the input/output load between physical disks.

Documentation for iostat command-tool: [http://linux.die.net/man/1/iostat](http://linux.die.net/man/1/iostat)
# Dependencies
- systat package 

The iostat command-line tool is part of the sysstat package available under the GNU General Public License.
# Metrics
### a) CPU statistic

Metric namespace prefix: /intel/linux/iostat/avg-cpu/

| Namespace | Description |
| --- | --- |
| %user | The percentage of CPU utilization that occurred while executing at the user level (the application usage) |
| %nice | The percentage of CPU utilization that occurred while executing at the user level with nice priority |
| %system | The percentage of CPU utilization that occurred while executing at the system level (the kernel usage) |
| %iowait | The percentage of time that the CPU or CPUs were idle during which the system had an outstanding disk I/O request |
| %steal | The percentage of time spent in involuntary wait by the virtual CPU or CPUs while the hypervisor was servicing another virtual processor |
| %idle | The percentage of time that the CPU or CPUs were idle and the systems did not have an outstanding disk I/O request |
### b) Device statistics

Metric namespace prefix: /intel/linux/iostat/device/{disk_or_partition}

| Name | Description |
| --- | --- |
| rrqm_per_sec | The number of read requests merged per second queued to the device |
| wrqm_per_sec | The number of write requests merged per second queued to the device |
| r_per_sec | The number of read requests issued to the device per second |
| w_per_sec | The number of write requests issued to the device per second |
| rkB_per_sec | The number of kilobytes read from the device per second |
| wkB_per_sec | The number of kilobytes written to the device per second |
| avgrq-sz | The average size (in sectors) of the requests issued to the device |
| avgqu-sz | The average queue length of the requests issued to the device |
| await | The average time (milliseconds) for I/O requests issued to the device to be served This includes the time spent by the requests in queue and the time spent servicing them |
| r_await | The average time (in milliseconds) for read requests issued to the device to be served which includes the time spent by the requests in queue and the time spent servicing them |
| w_await | The average time (in milliseconds) for write requests issued to the device to be served which includes the time spent by the requests in queue and the time spent servicing them |
| svctm | The average service time (in milliseconds) for I/O requests issued to the device - Warning! Do not trust this field; it will be removed in a future version of sysstat |
| %util | Percentage of CPU time during which I/O requests were issued to the device (bandwidth utilization for the device); device saturation occurs when this values is close to 100%\ |
# Sample output

From snapctl task watch
![image](https://cloud.githubusercontent.com/assets/11335874/10905932/e086f4fe-821d-11e5-8be9-8b32616944fb.png)
