### PR TITLE
Fixes #9: Adds doc comment for running plugin in a Docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This plugin is used in the [snap framework] (http://github.com/intelsdi-x/snap).
   * [System Requirements](#system-requirements)
   * [Installation](#installation)
   * [Configuration and Usage](#configuration-and-usage)
+      * [Docker](#docker)
 2. [Documentation](#documentation)
   * [Collected Metrics](#collected-metrics)
   * [Examples](#examples)
@@ -69,6 +70,9 @@ This builds the plugin in `/build/rootfs/`
 
 By default iostat executable binary are searched in the directories named by the PATH environment. 
 Customize path to iostat executable is also possible by setting environment variable `export SNAP_IOSTAT_PATH=/path/to/iostat/bin`
+
+#### Docker
+* If you are running this plugin in a Docker container, you need to run the container with the flag `--pid host` to map your container's `/proc` to the host proc.
 
 ## Documentation
 


### PR DESCRIPTION
Fixes #9

Testing
If you run the container with `--pid host` it gets the host `/proc`

```
tiffany@1404LTS:~$ ls /proc/
1      1227  1326   14678  1641   1853   1988  21     22222  2537   2932  45   55   9       buddyinfo    fs          mdstat        softirqs           vmstat
10     1228  13287  14765  1647   1855   2     2109   22225  2546   2936  46   550  9022    bus          interrupts  meminfo       stat               zoneinfo
1006   1229  1333   1497   1648   1857   20    2122   22226  2582   2941  47   682  912     cgroups      iomem       misc          swaps
1023   123   1334   15     1651   18572  2012  2131   22227  2583   2943  478  7    917     cmdline      ioports     modules       sys
1043   1230  1344   1511   1662   18581  2020  2143   22246  25846  2965  48   710  920     consoles     irq         mounts        sysrq-trigger
1048   1231  1347   15355  1667   18643  2026  2149   2232   25952  2966  49   717  929     cpuinfo      kallsyms    mtrr          sysvipc
1065   1232  136    1597   17     1873   2028  2161   2233   25955  2972  493  75   931     crypto       kcore       net           thread-self
1067   1233  137    16     1703   1876   2030  2173   2266   26     3     498  76   9697    devices      keys        pagetypeinfo  timer_list
1081   125   138    1603   18     19     2036  2174   2267   26037  31    5    8    9706    diskstats    key-users   partitions    timer_stats
11     126   14     1606   1839   1914   2061  2180   23     26046  32    50   843  9707    dma          kmsg        sched_debug   tty
1170   13    1408   1613   18397  1952   2070  2187   2321   2616   33    510  847  9898    driver       kpagecount  schedstat     uptime
11831  1312  1412   1617   1846   1955   2083  22     2346   2617   3882  518  854  9908    execdomains  kpageflags  scsi          version
1223   1314  1466   1626   1847   1969   2087  2212   24     27     4083  527  855  acpi    fb           loadavg     self          version_signature
1226   1323  14675  1638   1851   1972   2092  22221  25     2930   417   528  858  asound  filesystems  locks       slabinfo      vmallocinfo
```

```
tiffany@1404LTS:~$ docker run -it --pid host ubuntu bash
root@d8edfe84f6db:/# ls /proc
1      1223  13     138    1597  1662   1857   1914  2030  2149   22227  2546   2930  3882  50   76    929        cmdline      interrupts  locks         scsi           tty
10     1226  1312   14     16    1667   18572  1952  2036  2161   22246  2582   2932  4083  510  8     931        consoles     iomem       mdstat        self           uptime
1006   1227  1314   1408   1603  17     18581  1955  2061  2173   2232   2583   2936  417   518  843   9697       cpuinfo      ioports     meminfo       slabinfo       version
1023   1228  1323   1412   1606  1703   18728  1969  2070  2174   2233   25846  2941  45    527  847   9706       crypto       irq         misc          softirqs       version_signature
1043   1229  1326   1466   1613  18     1873   1972  2083  2180   2266   25952  2943  46    528  854   9707       devices      kallsyms    modules       stat           vmallocinfo
1048   123   13287  14675  1617  1839   1876   1988  2087  2187   2267   25955  2965  47    55   855   9898       diskstats    kcore       mounts        swaps          vmstat
1065   1230  1333   14678  1626  18397  18785  2     2092  22     23     26     2966  478   550  858   9908       dma          key-users   mtrr          sys            zoneinfo
1067   1231  1334   14765  1638  1846   18787  20    21    2212   2321   26037  2972  48    682  9     acpi       driver       keys        net           sysrq-trigger
1081   1232  1344   1497   1641  1847   18805  2012  2109  22221  2346   26046  3     49    7    9022  asound     execdomains  kmsg        pagetypeinfo  sysvipc
11     1233  1347   15     1647  1851   18812  2020  2122  22222  24     2616   31    493   710  912   buddyinfo  fb           kpagecount  partitions    thread-self
1170   125   136    1511   1648  1853   18839  2026  2131  22225  25     2617   32    498   717  917   bus        filesystems  kpageflags  sched_debug   timer_list
11831  126   137    15355  1651  1855   19     2028  2143  22226  2537   27     33    5     75   920   cgroups    fs           loadavg     schedstat     timer_stats
```
Which you can compare to running without the flag
```
tiffany@1404LTS:~$ docker run -it ubuntu bash
root@b559788497d2:/# ls /proc
1          bus       crypto     execdomains  iomem     key-users   loadavg  modules       partitions   slabinfo  sysrq-trigger  tty                vmstat
9          cgroups   devices    fb           ioports   keys        locks    mounts        sched_debug  softirqs  sysvipc        uptime             zoneinfo
acpi       cmdline   diskstats  filesystems  irq       kmsg        mdstat   mtrr          schedstat    stat      thread-self    version
asound     consoles  dma        fs           kallsyms  kpagecount  meminfo  net           scsi         swaps     timer_list     version_signature
buddyinfo  cpuinfo   driver     interrupts   kcore     kpageflags  misc     pagetypeinfo  self         sys       timer_stats    vmallocinfo
```

`/sys` should be the host's sys by default. sys shows the vboxguest which wouldn't show up if it was just from the container
```
tiffany@1404LTS:~$ docker run -it ubuntu bash
root@f1f52f8a982e:/# ls /sys/module/
8250          block             dynamic_debug   ima             libahci    nf_conntrack            pcie_aspm    scsi_mod            sr_mod     veth                xor
8250_fintek   bluetooth         e1000           intel_idle      libata     nf_conntrack_ipv4       pciehp       serio_raw           stp        video               xt_addrtype
ablk_helper   bnep              edd             ip_tables       libcrc32c  nf_defrag_ipv4          ppdev        sg                  sysrq      virtio_balloon      xt_conntrack
ac97_bus      br_netfilter      efivars         ipt_MASQUERADE  llc        nf_nat                  ppp_generic  snd                 tcp_cubic  virtio_blk          xt_nat
acpi          brd               ehci_hcd        iptable_filter  loop       nf_nat_ipv4             printk       snd_ac97_codec      thermal    virtio_mmio         xt_tcpudp
acpi_cpufreq  bridge            firmware_class  iptable_nat     lp         nf_nat_masquerade_ipv4  processor    snd_intel8x0        tpm        virtio_net          xz_dec
acpiphp       btrfs             fuse            ipv6            lrw        nls_utf8                psmouse      snd_pcm             tpm_tis    virtio_pci          zswap
aes_x86_64    cpuidle           gf128mul        isofs           mac_hid    ntfs                    pstore       snd_rawmidi         ufs        vt
aesni_intel   crc32_pclmul      glue_helper     jfs             md_mod     parport                 qnx4         snd_seq             uhci_hcd   workqueue
ahci          crct10dif_pclmul  hfs             joydev          minix      parport_pc              raid6_pq     snd_seq_device      uinput     x_tables
apparmor      cryptd            hfsplus         kdb             module     pata_acpi               rcupdate     snd_seq_midi        usbcore    xen_acpi_processor
ata_generic   debug_core        hid             kernel          mousedev   pata_sis                rcutree      snd_seq_midi_event  usbhid     xen_blkfront
ata_piix      dm_mod            hid_generic     keyboard        msdos      pcc_cpufreq             rfcomm       snd_timer           vboxguest  xen_netfront
aufs          dns_resolver      i2c_piix4       kgdb_nmi        msr        pci_hotplug             rfkill       soundcore           vboxsf     xfs
battery       drm               i8042           kgdboc          netpoll    pci_slot                rng_core     spurious            vboxvideo  xhci_hcd
```

@intelsdi-x/plugin-maintainers 