### PR TITLE
Update namespace to /intel/iostat

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ This plugin has the ability to gather the following metrics:
 
 * **CPU statistic**
 
-Metric namespace prefix: /intel/linux/iostat/avg-cpu/
+Metric namespace prefix: /intel/iostat/avg-cpu/
 
 Namespace | Description 
 ------------ | -------------
@@ -97,7 +97,7 @@ Namespace | Description
 
 * **Device statistics**
 
-Metric namespace prefix: /intel/linux/iostat/device/{disk_or_partition}
+Metric namespace prefix: /intel/iostat/device/{disk_or_partition}
 
 Name | Description 
 ------------ | -------------
@@ -164,47 +164,47 @@ $ snaptel task watch 02dd7ff4-8106-47e9-8b86-70067cd0a850
 
 Watching Task (02dd7ff4-8106-47e9-8b86-70067cd0a850):
 NAMESPACE                                        DATA    TIMESTAMP                               SOURCE
-/intel/linux/iostat/avg-cpu/%idle                97.62   2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/avg-cpu/%iowait              1.13    2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/avg-cpu/%nice                0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/avg-cpu/%steal               0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/avg-cpu/%system              0.5     2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/avg-cpu/%user                0.75    2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/ALL/%util             1.69    2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/ALL/r_per_sec         0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/ALL/rkB_per_sec       0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/ALL/rrqm_per_sec      0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/ALL/w_per_sec         133     2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/ALL/wkB_per_sec       50672   2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/ALL/wrqm_per_sec      326     2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/sda1/%util            0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/sda1/r_per_sec        0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/sda1/rkB_per_sec      0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/sda1/rrqm_per_sec     0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/sda1/w_per_sec        0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/sda1/wkB_per_sec      0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/sda1/wrqm_per_sec     0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/sdb/%util             6.8     2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/sdb/r_per_sec         0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/sdb/rkB_per_sec       0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/sdb/rrqm_per_sec      0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/sdb/w_per_sec         68      2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/sdb/wkB_per_sec       25336   2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/sdb/wrqm_per_sec      163     2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/sdb1/%util            6.7     2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/sdb1/r_per_sec        0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/sdb1/rkB_per_sec      0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/sdb1/rrqm_per_sec     0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/sdb1/w_per_sec        65      2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/sdb1/wkB_per_sec      25336   2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/sdb1/wrqm_per_sec     163     2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/sdb2/%util            0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/sdb2/r_per_sec        0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/sdb2/rkB_per_sec      0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/sdb2/rrqm_per_sec     0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/sdb2/w_per_sec        0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/sdb2/wkB_per_sec      0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
-/intel/linux/iostat/device/sdb2/wrqm_per_sec     0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/avg-cpu/%idle                97.62   2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/avg-cpu/%iowait              1.13    2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/avg-cpu/%nice                0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/avg-cpu/%steal               0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/avg-cpu/%system              0.5     2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/avg-cpu/%user                0.75    2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/ALL/%util             1.69    2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/ALL/r_per_sec         0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/ALL/rkB_per_sec       0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/ALL/rrqm_per_sec      0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/ALL/w_per_sec         133     2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/ALL/wkB_per_sec       50672   2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/ALL/wrqm_per_sec      326     2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/sda1/%util            0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/sda1/r_per_sec        0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/sda1/rkB_per_sec      0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/sda1/rrqm_per_sec     0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/sda1/w_per_sec        0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/sda1/wkB_per_sec      0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/sda1/wrqm_per_sec     0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/sdb/%util             6.8     2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/sdb/r_per_sec         0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/sdb/rkB_per_sec       0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/sdb/rrqm_per_sec      0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/sdb/w_per_sec         68      2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/sdb/wkB_per_sec       25336   2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/sdb/wrqm_per_sec      163     2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/sdb1/%util            6.7     2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/sdb1/r_per_sec        0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/sdb1/rkB_per_sec      0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/sdb1/rrqm_per_sec     0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/sdb1/w_per_sec        65      2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/sdb1/wkB_per_sec      25336   2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/sdb1/wrqm_per_sec     163     2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/sdb2/%util            0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/sdb2/r_per_sec        0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/sdb2/rkB_per_sec      0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/sdb2/rrqm_per_sec     0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/sdb2/w_per_sec        0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/sdb2/wkB_per_sec      0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
+/intel/iostat/device/sdb2/wrqm_per_sec     0       2015-12-01 05:39:57.79589855 -0500 EST  gklab-108-109-110-111
 ```
 
 Stop task:

--- a/examples/tasks/iostat-file.json
+++ b/examples/tasks/iostat-file.json
@@ -7,29 +7,29 @@
   "workflow": {
     "collect": {
       "metrics": {
-        "/intel/linux/iostat/avg-cpu/%user": {},
-        "/intel/linux/iostat/avg-cpu/%system": {},
-        "/intel/linux/iostat/avg-cpu/%idle": {},
-        "/intel/linux/iostat/avg-cpu/%iowait": {},
-        "/intel/linux/iostat/avg-cpu/%nice": {},
-        "/intel/linux/iostat/avg-cpu/%steal": {},
-        "/intel/linux/iostat/device/sda1/rrqm_per_sec": {},
-        "/intel/linux/iostat/device/sda1/wrqm_per_sec": {},
-        "/intel/linux/iostat/device/sda1/r_per_sec": {},
-        "/intel/linux/iostat/device/sda1/w_per_sec": {},
-        "/intel/linux/iostat/device/sda1/rkB_per_sec": {},
-        "/intel/linux/iostat/device/sda1/wkB_per_sec": {},
-        "/intel/linux/iostat/device/sda1/%util": {},
-        "/intel/linux/iostat/device/ALL/rrqm_per_sec": {},
-        "/intel/linux/iostat/device/ALL/wrqm_per_sec": {},
-        "/intel/linux/iostat/device/ALL/r_per_sec": {},
-        "/intel/linux/iostat/device/ALL/w_per_sec": {},
-        "/intel/linux/iostat/device/ALL/rkB_per_sec": {},
-        "/intel/linux/iostat/device/ALL/wkB_per_sec": {},
-        "/intel/linux/iostat/device/ALL/%util": {}
+        "/intel/iostat/avg-cpu/%user": {},
+        "/intel/iostat/avg-cpu/%system": {},
+        "/intel/iostat/avg-cpu/%idle": {},
+        "/intel/iostat/avg-cpu/%iowait": {},
+        "/intel/iostat/avg-cpu/%nice": {},
+        "/intel/iostat/avg-cpu/%steal": {},
+        "/intel/iostat/device/sda1/rrqm_per_sec": {},
+        "/intel/iostat/device/sda1/wrqm_per_sec": {},
+        "/intel/iostat/device/sda1/r_per_sec": {},
+        "/intel/iostat/device/sda1/w_per_sec": {},
+        "/intel/iostat/device/sda1/rkB_per_sec": {},
+        "/intel/iostat/device/sda1/wkB_per_sec": {},
+        "/intel/iostat/device/sda1/%util": {},
+        "/intel/iostat/device/ALL/rrqm_per_sec": {},
+        "/intel/iostat/device/ALL/wrqm_per_sec": {},
+        "/intel/iostat/device/ALL/r_per_sec": {},
+        "/intel/iostat/device/ALL/w_per_sec": {},
+        "/intel/iostat/device/ALL/rkB_per_sec": {},
+        "/intel/iostat/device/ALL/wkB_per_sec": {},
+        "/intel/iostat/device/ALL/%util": {}
       },
       "config": {
-        "/intel/linux/iostat": {
+        "/intel/iostat": {
           "ReportSinceBoot": false
         }
       },

--- a/examples/tasks/iostat-influxdb.json
+++ b/examples/tasks/iostat-influxdb.json
@@ -7,29 +7,29 @@
   "workflow": {
     "collect": {
       "metrics": {
-        "/intel/linux/iostat/avg-cpu/%user": {},
-        "/intel/linux/iostat/avg-cpu/%system": {},
-        "/intel/linux/iostat/avg-cpu/%idle": {},
-        "/intel/linux/iostat/avg-cpu/%iowait": {},
-        "/intel/linux/iostat/avg-cpu/%nice": {},
-        "/intel/linux/iostat/avg-cpu/%steal": {},
-        "/intel/linux/iostat/device/sda1/rrqm_per_sec": {},
-        "/intel/linux/iostat/device/sda1/wrqm_per_sec": {},
-        "/intel/linux/iostat/device/sda1/r_per_sec": {},
-        "/intel/linux/iostat/device/sda1/w_per_sec": {},
-        "/intel/linux/iostat/device/sda1/rkB_per_sec": {},
-        "/intel/linux/iostat/device/sda1/wkB_per_sec": {},
-        "/intel/linux/iostat/device/sda1/%util": {},
-        "/intel/linux/iostat/device/ALL/rrqm_per_sec": {},
-        "/intel/linux/iostat/device/ALL/wrqm_per_sec": {},
-        "/intel/linux/iostat/device/ALL/r_per_sec": {},
-        "/intel/linux/iostat/device/ALL/w_per_sec": {},
-        "/intel/linux/iostat/device/ALL/rkB_per_sec": {},
-        "/intel/linux/iostat/device/ALL/wkB_per_sec": {},
-        "/intel/linux/iostat/device/ALL/%util": {}
+        "/intel/iostat/avg-cpu/%user": {},
+        "/intel/iostat/avg-cpu/%system": {},
+        "/intel/iostat/avg-cpu/%idle": {},
+        "/intel/iostat/avg-cpu/%iowait": {},
+        "/intel/iostat/avg-cpu/%nice": {},
+        "/intel/iostat/avg-cpu/%steal": {},
+        "/intel/iostat/device/sda1/rrqm_per_sec": {},
+        "/intel/iostat/device/sda1/wrqm_per_sec": {},
+        "/intel/iostat/device/sda1/r_per_sec": {},
+        "/intel/iostat/device/sda1/w_per_sec": {},
+        "/intel/iostat/device/sda1/rkB_per_sec": {},
+        "/intel/iostat/device/sda1/wkB_per_sec": {},
+        "/intel/iostat/device/sda1/%util": {},
+        "/intel/iostat/device/ALL/rrqm_per_sec": {},
+        "/intel/iostat/device/ALL/wrqm_per_sec": {},
+        "/intel/iostat/device/ALL/r_per_sec": {},
+        "/intel/iostat/device/ALL/w_per_sec": {},
+        "/intel/iostat/device/ALL/rkB_per_sec": {},
+        "/intel/iostat/device/ALL/wkB_per_sec": {},
+        "/intel/iostat/device/ALL/%util": {}
       },
       "config": {
-        "/intel/linux/iostat": {
+        "/intel/iostat": {
           "ReportSinceBoot": false
         }
       },

--- a/iostat/iostat.go
+++ b/iostat/iostat.go
@@ -39,7 +39,7 @@ const (
 	// Name of plugin
 	Name = "iostat"
 	// Version of plugin
-	Version = 5
+	Version = 6
 	// Type of plugin
 	Type         = plugin.CollectorPluginType
 	deviceMetric = "device"
@@ -79,14 +79,14 @@ func (iostat *IOSTAT) CollectMetrics(mts []plugin.MetricType) ([]plugin.MetricTy
 
 	for _, mt := range mts {
 		ns := mt.Namespace()
-		if len(ns) < 5 {
+		if len(ns) < 4 {
 			return nil, fmt.Errorf("Namespace length is too short (len = %d)", len(ns))
 		}
 
-		if ns[4].Value == "*" {
-			if ns[3].Value == deviceMetric {
+		if ns[3].Value == "*" {
+			if ns[2].Value == deviceMetric {
 				for k, _ := range data {
-					reg := ns[:3].String() + "/device/.*" + ns[5:].String()
+					reg := ns[:2].String() + "/device/.*" + ns[4:].String()
 					matched, err := regexp.MatchString(reg, k)
 					if !matched {
 						continue
@@ -95,14 +95,14 @@ func (iostat *IOSTAT) CollectMetrics(mts []plugin.MetricType) ([]plugin.MetricTy
 						return nil, fmt.Errorf("Error matching namespaces %v", ns)
 					}
 
-					dev, err := extractFromNamespace(k, 4)
+					dev, err := extractFromNamespace(k, 3)
 					if err != nil {
 						return nil, err
 					}
 
 					nsCopy := make(core.Namespace, len(ns))
 					copy(nsCopy, ns)
-					nsCopy[4].Value = dev
+					nsCopy[3].Value = dev
 
 					if v, ok := data[nsCopy.String()]; ok {
 						metrics = append(metrics, plugin.MetricType{
@@ -146,16 +146,16 @@ func (iostat *IOSTAT) GetMetricTypes(_ plugin.ConfigType) ([]plugin.MetricType, 
 	for _, namespace := range namespaces {
 		ns := core.NewNamespace(strings.Split(strings.TrimPrefix(namespace, "/"), "/")...)
 
-		if len(ns) < 5 {
+		if len(ns) < 4 {
 			return nil, fmt.Errorf("Namespace length is too short (len = %d)", len(ns))
 		}
 		// terminal metric name
 		mItem := ns[len(ns)-1]
-		if ns[3].Value == deviceMetric {
+		if ns[2].Value == deviceMetric {
 			if !mList[mItem.Value] {
 				mList[mItem.Value] = true
 				metric = plugin.MetricType{
-					Namespace_: core.NewNamespace(parser.NsVendor, parser.NsClass, parser.NsType, deviceMetric).
+					Namespace_: core.NewNamespace(parser.NsVendor, parser.NsType, deviceMetric).
 						AddDynamicElement("device_id", "Device ID").
 						AddStaticElement(mItem.Value),
 					Description_: "dynamic device metric: " + mItem.Value}

--- a/iostat/iostat_test.go
+++ b/iostat/iostat_test.go
@@ -37,105 +37,105 @@ import (
 // 	value float64
 // }
 
-// var ns_prefix = []string{parser.NsVendor, parser.NsClass, parser.NsType}
+// var ns_prefix = []string{parser.NsVendor,  parser.NsType}
 
 // var mockKV = []Mock{
-// 	{"/intel/linux/iostat/avg-cpu/%user", 0.50},
-// 	{"/intel/linux/iostat/avg-cpu/%nice", 0.00},
-// 	{"/intel/linux/iostat/avg-cpu/%system", 0.13},
-// 	{"/intel/linux/iostat/avg-cpu/%iowait", 0.00},
-// 	{"/intel/linux/iostat/avg-cpu/%steal", 0.00},
-// 	{"/intel/linux/iostat/avg-cpu/%idle", 99.37},
-// 	{"/intel/linux/iostat/device/sda/rrqm_per_sec", 0.00},
-// 	{"/intel/linux/iostat/device/sdb/wrqm_per_sec", 0.33},
-// 	{"/intel/linux/iostat/device/sda1/r_per_sec", 0.00},
-// 	{"/intel/linux/iostat/device/sdb1/w_per_sec", 0.08},
-// 	{"/intel/linux/iostat/device/sda2/rkB_per_sec", 0.00},
-// 	{"/intel/linux/iostat/device/sdb2/wkB_per_sec", 4.55},
-// 	{"/intel/linux/iostat/device/sda3/avgrq-sz", 8.00},
-// 	{"/intel/linux/iostat/device/sda4/avgqu-sz", 0.00},
-// 	{"/intel/linux/iostat/device/sdb/await", 1.83},
-// 	{"/intel/linux/iostat/device/sdb/r_await", 0.94},
-// 	{"/intel/linux/iostat/device/sdb/w_await", 2.00},
-// 	{"/intel/linux/iostat/device/sdb/svctm", 0.06},
-// 	{"/intel/linux/iostat/device/sdb/%util", 0.00},
-// 	{"/intel/linux/iostat/device/ALL/rrqm_per_sec", 0.05},
-// 	{"/intel/linux/iostat/device/ALL/wkB_per_sec", 30.68},
+// 	{"/intel/iostat/avg-cpu/%user", 0.50},
+// 	{"/intel/iostat/avg-cpu/%nice", 0.00},
+// 	{"/intel/iostat/avg-cpu/%system", 0.13},
+// 	{"/intel/iostat/avg-cpu/%iowait", 0.00},
+// 	{"/intel/iostat/avg-cpu/%steal", 0.00},
+// 	{"/intel/iostat/avg-cpu/%idle", 99.37},
+// 	{"/intel/iostat/device/sda/rrqm_per_sec", 0.00},
+// 	{"/intel/iostat/device/sdb/wrqm_per_sec", 0.33},
+// 	{"/intel/iostat/device/sda1/r_per_sec", 0.00},
+// 	{"/intel/iostat/device/sdb1/w_per_sec", 0.08},
+// 	{"/intel/iostat/device/sda2/rkB_per_sec", 0.00},
+// 	{"/intel/iostat/device/sdb2/wkB_per_sec", 4.55},
+// 	{"/intel/iostat/device/sda3/avgrq-sz", 8.00},
+// 	{"/intel/iostat/device/sda4/avgqu-sz", 0.00},
+// 	{"/intel/iostat/device/sdb/await", 1.83},
+// 	{"/intel/iostat/device/sdb/r_await", 0.94},
+// 	{"/intel/iostat/device/sdb/w_await", 2.00},
+// 	{"/intel/iostat/device/sdb/svctm", 0.06},
+// 	{"/intel/iostat/device/sdb/%util", 0.00},
+// 	{"/intel/iostat/device/ALL/rrqm_per_sec", 0.05},
+// 	{"/intel/iostat/device/ALL/wkB_per_sec", 30.68},
 // }
 
 var refMap = map[string]interface{}{
-	"/intel/linux/iostat/device/sda1/%util":        0,
-	"/intel/linux/iostat/device/sda4/await":        0.11,
-	"/intel/linux/iostat/device/sdb1/r_per_sec":    0.04,
-	"/intel/linux/iostat/device/sda/wrqm_per_sec":  0,
-	"/intel/linux/iostat/device/ALL/avgrq-sz":      45.65,
-	"/intel/linux/iostat/device/sda4/avgrq-sz":     8,
-	"/intel/linux/iostat/device/sdb2/avgqu-sz":     0,
-	"/intel/linux/iostat/device/sda4/avgqu-sz":     0,
-	"/intel/linux/iostat/device/ALL/%util":         0,
-	"/intel/linux/iostat/device/sda/r_per_sec":     0,
-	"/intel/linux/iostat/device/sdb/avgrq-sz":      45.7,
-	"/intel/linux/iostat/device/sda/avgqu-sz":      0,
-	"/intel/linux/iostat/device/ALL/await":         1.82,
-	"/intel/linux/iostat/device/sda3/w_per_sec":    0,
-	"/intel/linux/iostat/device/ALL/avgqu-sz":      0,
-	"/intel/linux/iostat/device/sda3/rrqm_per_sec": 0,
-	"/intel/linux/iostat/device/sdb1/wrqm_per_sec": 0.07,
-	"/intel/linux/iostat/device/sda4/r_per_sec":    0,
-	"/intel/linux/iostat/device/sdb1/rrqm_per_sec": 0,
-	"/intel/linux/iostat/device/sda4/w_per_sec":    0,
-	"/intel/linux/iostat/device/sdb/w_per_sec":     0.64,
-	"/intel/linux/iostat/device/sdb/%util":         0,
-	"/intel/linux/iostat/device/sdb2/%util":        0,
-	"/intel/linux/iostat/device/sdb1/await":        9.81,
-	"/intel/linux/iostat/device/sda1/rrqm_per_sec": 0,
-	"/intel/linux/iostat/device/sdb/wrqm_per_sec":  0.33,
-	"/intel/linux/iostat/device/sdb2/r_per_sec":    0.09,
-	"/intel/linux/iostat/device/sda1/avgqu-sz":     0,
-	"/intel/linux/iostat/device/sdb1/%util":        0,
-	"/intel/linux/iostat/device/sda4/rrqm_per_sec": 0,
-	"/intel/linux/iostat/device/sda/w_per_sec":     0,
-	"/intel/linux/iostat/device/sda2/w_per_sec":    0,
-	"/intel/linux/iostat/device/sda1/w_per_sec":    0,
-	"/intel/linux/iostat/device/sdb1/avgrq-sz":     185.22,
-	"/intel/linux/iostat/device/sda1/await":        0.12,
-	"/intel/linux/iostat/device/ALL/rrqm_per_sec":  0.05,
-	"/intel/linux/iostat/device/sda4/wrqm_per_sec": 0,
-	"/intel/linux/iostat/device/sdb2/w_per_sec":    0.55,
-	"/intel/linux/iostat/device/sda2/avgrq-sz":     7.8,
-	"/intel/linux/iostat/device/sdb2/rrqm_per_sec": 0.02,
-	"/intel/linux/iostat/device/sdb/r_per_sec":     0.13,
-	"/intel/linux/iostat/device/sdb2/avgrq-sz":     19.87,
-	"/intel/linux/iostat/device/sda3/avgqu-sz":     0,
-	"/intel/linux/iostat/device/sda4/%util":        0,
-	"/intel/linux/iostat/device/sda/await":         0.1,
-	"/intel/linux/iostat/device/sda2/wrqm_per_sec": 0,
-	"/intel/linux/iostat/device/sda3/avgrq-sz":     8,
-	"/intel/linux/iostat/device/sdb1/avgqu-sz":     0,
-	"/intel/linux/iostat/device/sdb/rrqm_per_sec":  0.02,
-	"/intel/linux/iostat/device/sdb2/wrqm_per_sec": 0.26,
-	"/intel/linux/iostat/device/sdb1/w_per_sec":    0.08,
-	"/intel/linux/iostat/device/sda2/r_per_sec":    0,
-	"/intel/linux/iostat/device/ALL/w_per_sec":     1.27,
-	"/intel/linux/iostat/device/sdb/await":         1.83,
-	"/intel/linux/iostat/device/sda2/await":        0.08,
-	"/intel/linux/iostat/device/sda2/rrqm_per_sec": 0,
-	"/intel/linux/iostat/device/ALL/wrqm_per_sec":  0.66,
-	"/intel/linux/iostat/device/sda3/r_per_sec":    0,
-	"/intel/linux/iostat/device/ALL/r_per_sec":     0.26,
-	"/intel/linux/iostat/device/sdb/avgqu-sz":      0,
-	"/intel/linux/iostat/device/sda/%util":         0,
-	"/intel/linux/iostat/device/sdb2/await":        0.34,
-	"/intel/linux/iostat/device/sda3/wrqm_per_sec": 0,
-	"/intel/linux/iostat/device/sda/avgrq-sz":      8.06,
-	"/intel/linux/iostat/device/sda1/avgrq-sz":     8.19,
-	"/intel/linux/iostat/device/sda2/avgqu-sz":     0,
-	"/intel/linux/iostat/device/sda3/%util":        0,
-	"/intel/linux/iostat/device/sda2/%util":        0,
-	"/intel/linux/iostat/device/sda3/await":        0.12,
-	"/intel/linux/iostat/device/sda/rrqm_per_sec":  0,
-	"/intel/linux/iostat/device/sda1/wrqm_per_sec": 0,
-	"/intel/linux/iostat/device/sda1/r_per_sec":    0,
+	"/intel/iostat/device/sda1/%util":        0,
+	"/intel/iostat/device/sda4/await":        0.11,
+	"/intel/iostat/device/sdb1/r_per_sec":    0.04,
+	"/intel/iostat/device/sda/wrqm_per_sec":  0,
+	"/intel/iostat/device/ALL/avgrq-sz":      45.65,
+	"/intel/iostat/device/sda4/avgrq-sz":     8,
+	"/intel/iostat/device/sdb2/avgqu-sz":     0,
+	"/intel/iostat/device/sda4/avgqu-sz":     0,
+	"/intel/iostat/device/ALL/%util":         0,
+	"/intel/iostat/device/sda/r_per_sec":     0,
+	"/intel/iostat/device/sdb/avgrq-sz":      45.7,
+	"/intel/iostat/device/sda/avgqu-sz":      0,
+	"/intel/iostat/device/ALL/await":         1.82,
+	"/intel/iostat/device/sda3/w_per_sec":    0,
+	"/intel/iostat/device/ALL/avgqu-sz":      0,
+	"/intel/iostat/device/sda3/rrqm_per_sec": 0,
+	"/intel/iostat/device/sdb1/wrqm_per_sec": 0.07,
+	"/intel/iostat/device/sda4/r_per_sec":    0,
+	"/intel/iostat/device/sdb1/rrqm_per_sec": 0,
+	"/intel/iostat/device/sda4/w_per_sec":    0,
+	"/intel/iostat/device/sdb/w_per_sec":     0.64,
+	"/intel/iostat/device/sdb/%util":         0,
+	"/intel/iostat/device/sdb2/%util":        0,
+	"/intel/iostat/device/sdb1/await":        9.81,
+	"/intel/iostat/device/sda1/rrqm_per_sec": 0,
+	"/intel/iostat/device/sdb/wrqm_per_sec":  0.33,
+	"/intel/iostat/device/sdb2/r_per_sec":    0.09,
+	"/intel/iostat/device/sda1/avgqu-sz":     0,
+	"/intel/iostat/device/sdb1/%util":        0,
+	"/intel/iostat/device/sda4/rrqm_per_sec": 0,
+	"/intel/iostat/device/sda/w_per_sec":     0,
+	"/intel/iostat/device/sda2/w_per_sec":    0,
+	"/intel/iostat/device/sda1/w_per_sec":    0,
+	"/intel/iostat/device/sdb1/avgrq-sz":     185.22,
+	"/intel/iostat/device/sda1/await":        0.12,
+	"/intel/iostat/device/ALL/rrqm_per_sec":  0.05,
+	"/intel/iostat/device/sda4/wrqm_per_sec": 0,
+	"/intel/iostat/device/sdb2/w_per_sec":    0.55,
+	"/intel/iostat/device/sda2/avgrq-sz":     7.8,
+	"/intel/iostat/device/sdb2/rrqm_per_sec": 0.02,
+	"/intel/iostat/device/sdb/r_per_sec":     0.13,
+	"/intel/iostat/device/sdb2/avgrq-sz":     19.87,
+	"/intel/iostat/device/sda3/avgqu-sz":     0,
+	"/intel/iostat/device/sda4/%util":        0,
+	"/intel/iostat/device/sda/await":         0.1,
+	"/intel/iostat/device/sda2/wrqm_per_sec": 0,
+	"/intel/iostat/device/sda3/avgrq-sz":     8,
+	"/intel/iostat/device/sdb1/avgqu-sz":     0,
+	"/intel/iostat/device/sdb/rrqm_per_sec":  0.02,
+	"/intel/iostat/device/sdb2/wrqm_per_sec": 0.26,
+	"/intel/iostat/device/sdb1/w_per_sec":    0.08,
+	"/intel/iostat/device/sda2/r_per_sec":    0,
+	"/intel/iostat/device/ALL/w_per_sec":     1.27,
+	"/intel/iostat/device/sdb/await":         1.83,
+	"/intel/iostat/device/sda2/await":        0.08,
+	"/intel/iostat/device/sda2/rrqm_per_sec": 0,
+	"/intel/iostat/device/ALL/wrqm_per_sec":  0.66,
+	"/intel/iostat/device/sda3/r_per_sec":    0,
+	"/intel/iostat/device/ALL/r_per_sec":     0.26,
+	"/intel/iostat/device/sdb/avgqu-sz":      0,
+	"/intel/iostat/device/sda/%util":         0,
+	"/intel/iostat/device/sdb2/await":        0.34,
+	"/intel/iostat/device/sda3/wrqm_per_sec": 0,
+	"/intel/iostat/device/sda/avgrq-sz":      8.06,
+	"/intel/iostat/device/sda1/avgrq-sz":     8.19,
+	"/intel/iostat/device/sda2/avgqu-sz":     0,
+	"/intel/iostat/device/sda3/%util":        0,
+	"/intel/iostat/device/sda2/%util":        0,
+	"/intel/iostat/device/sda3/await":        0.12,
+	"/intel/iostat/device/sda/rrqm_per_sec":  0,
+	"/intel/iostat/device/sda1/wrqm_per_sec": 0,
+	"/intel/iostat/device/sda1/r_per_sec":    0,
 }
 
 var mockCmdOut = `Linux 3.10.0-229.11.1.el7.x86_64 (gklab-108-166) 0/26/2015      _x86_64_        (8 CPU)
@@ -159,63 +159,63 @@ var mockCmdOut = `Linux 3.10.0-229.11.1.el7.x86_64 (gklab-108-166) 0/26/2015    
 
 var staticMockMts = []plugin.MetricType{
 	plugin.MetricType{
-		Namespace_: core.NewNamespace("intel", "linux", "iostat", "avg-cpu", "%user"),
+		Namespace_: core.NewNamespace("intel", "iostat", "avg-cpu", "%user"),
 	},
 	plugin.MetricType{
-		Namespace_: core.NewNamespace("intel", "linux", "iostat", "avg-cpu", "%nice"),
+		Namespace_: core.NewNamespace("intel", "iostat", "avg-cpu", "%nice"),
 	},
 	plugin.MetricType{
-		Namespace_: core.NewNamespace("intel", "linux", "iostat", "avg-cpu", "%system"),
+		Namespace_: core.NewNamespace("intel", "iostat", "avg-cpu", "%system"),
 	},
 	plugin.MetricType{
-		Namespace_: core.NewNamespace("intel", "linux", "iostat", "avg-cpu", "%iowait"),
+		Namespace_: core.NewNamespace("intel", "iostat", "avg-cpu", "%iowait"),
 	},
 	plugin.MetricType{
-		Namespace_: core.NewNamespace("intel", "linux", "iostat", "avg-cpu", "%steal"),
+		Namespace_: core.NewNamespace("intel", "iostat", "avg-cpu", "%steal"),
 	},
 	plugin.MetricType{
-		Namespace_: core.NewNamespace("intel", "linux", "iostat", "avg-cpu", "%idle"),
+		Namespace_: core.NewNamespace("intel", "iostat", "avg-cpu", "%idle"),
 	},
 }
 
 var dynamicMockMts = []plugin.MetricType{
 	plugin.MetricType{
-		Namespace_: core.NewNamespace("intel", "linux", "iostat", "device").
+		Namespace_: core.NewNamespace("intel", "iostat", "device").
 			AddDynamicElement("device_id", "Device ID").
 			AddStaticElement("%util"),
 	},
 	plugin.MetricType{
-		Namespace_: core.NewNamespace("intel", "linux", "iostat", "device").
+		Namespace_: core.NewNamespace("intel", "iostat", "device").
 			AddDynamicElement("device_id", "Device ID").
 			AddStaticElement("await"),
 	},
 	plugin.MetricType{
-		Namespace_: core.NewNamespace("intel", "linux", "iostat", "device").
+		Namespace_: core.NewNamespace("intel", "iostat", "device").
 			AddDynamicElement("device_id", "Device ID").
 			AddStaticElement("rrqm_per_sec"),
 	},
 	plugin.MetricType{
-		Namespace_: core.NewNamespace("intel", "linux", "iostat", "device").
+		Namespace_: core.NewNamespace("intel", "iostat", "device").
 			AddDynamicElement("device_id", "Device ID").
 			AddStaticElement("wrqm_per_sec"),
 	},
 	plugin.MetricType{
-		Namespace_: core.NewNamespace("intel", "linux", "iostat", "device").
+		Namespace_: core.NewNamespace("intel", "iostat", "device").
 			AddDynamicElement("device_id", "Device ID").
 			AddStaticElement("r_per_sec"),
 	},
 	plugin.MetricType{
-		Namespace_: core.NewNamespace("intel", "linux", "iostat", "device").
+		Namespace_: core.NewNamespace("intel", "iostat", "device").
 			AddDynamicElement("device_id", "Device ID").
 			AddStaticElement("w_per_sec"),
 	},
 	plugin.MetricType{
-		Namespace_: core.NewNamespace("intel", "linux", "iostat", "device").
+		Namespace_: core.NewNamespace("intel", "iostat", "device").
 			AddDynamicElement("device_id", "Device ID").
 			AddStaticElement("avgrq-sz"),
 	},
 	plugin.MetricType{
-		Namespace_: core.NewNamespace("intel", "linux", "iostat", "device").
+		Namespace_: core.NewNamespace("intel", "iostat", "device").
 			AddDynamicElement("device_id", "Device ID").
 			AddStaticElement("avgqu-sz"),
 	},
@@ -237,7 +237,7 @@ func TestIostat(t *testing.T) {
 	Convey("Given invalid metric namespace collect metrics", t, func() {
 		badMetrics := []plugin.MetricType{
 			plugin.MetricType{
-				Namespace_: core.NewNamespace("intel", "linux", "iostat", "device", "sda", "bad"),
+				Namespace_: core.NewNamespace("intel", "iostat", "device", "sda", "bad"),
 			},
 		}
 		So(func() { iostat.CollectMetrics(badMetrics) }, ShouldNotPanic)
@@ -297,25 +297,25 @@ func TestIostat(t *testing.T) {
 			namespaces = append(namespaces, m.Namespace().String())
 		}
 
-		So(namespaces, ShouldContain, "/intel/linux/iostat/avg-cpu/%idle")
-		So(namespaces, ShouldContain, "/intel/linux/iostat/avg-cpu/%iowait")
-		So(namespaces, ShouldContain, "/intel/linux/iostat/avg-cpu/%nice")
-		So(namespaces, ShouldContain, "/intel/linux/iostat/avg-cpu/%steal")
-		So(namespaces, ShouldContain, "/intel/linux/iostat/avg-cpu/%system")
-		So(namespaces, ShouldContain, "/intel/linux/iostat/avg-cpu/%user")
-		So(namespaces, ShouldContain, "/intel/linux/iostat/device/*/%util")
-		So(namespaces, ShouldContain, "/intel/linux/iostat/device/*/avgqu-sz")
-		So(namespaces, ShouldContain, "/intel/linux/iostat/device/*/avgrq-sz")
-		So(namespaces, ShouldContain, "/intel/linux/iostat/device/*/await")
-		So(namespaces, ShouldContain, "/intel/linux/iostat/device/*/r_await")
-		So(namespaces, ShouldContain, "/intel/linux/iostat/device/*/r_per_sec")
-		So(namespaces, ShouldContain, "/intel/linux/iostat/device/*/rkB_per_sec")
-		So(namespaces, ShouldContain, "/intel/linux/iostat/device/*/rrqm_per_sec")
-		So(namespaces, ShouldContain, "/intel/linux/iostat/device/*/svctm")
-		So(namespaces, ShouldContain, "/intel/linux/iostat/device/*/w_await")
-		So(namespaces, ShouldContain, "/intel/linux/iostat/device/*/w_per_sec")
-		So(namespaces, ShouldContain, "/intel/linux/iostat/device/*/wkB_per_sec")
-		So(namespaces, ShouldContain, "/intel/linux/iostat/device/*/wrqm_per_sec")
+		So(namespaces, ShouldContain, "/intel/iostat/avg-cpu/%idle")
+		So(namespaces, ShouldContain, "/intel/iostat/avg-cpu/%iowait")
+		So(namespaces, ShouldContain, "/intel/iostat/avg-cpu/%nice")
+		So(namespaces, ShouldContain, "/intel/iostat/avg-cpu/%steal")
+		So(namespaces, ShouldContain, "/intel/iostat/avg-cpu/%system")
+		So(namespaces, ShouldContain, "/intel/iostat/avg-cpu/%user")
+		So(namespaces, ShouldContain, "/intel/iostat/device/*/%util")
+		So(namespaces, ShouldContain, "/intel/iostat/device/*/avgqu-sz")
+		So(namespaces, ShouldContain, "/intel/iostat/device/*/avgrq-sz")
+		So(namespaces, ShouldContain, "/intel/iostat/device/*/await")
+		So(namespaces, ShouldContain, "/intel/iostat/device/*/r_await")
+		So(namespaces, ShouldContain, "/intel/iostat/device/*/r_per_sec")
+		So(namespaces, ShouldContain, "/intel/iostat/device/*/rkB_per_sec")
+		So(namespaces, ShouldContain, "/intel/iostat/device/*/rrqm_per_sec")
+		So(namespaces, ShouldContain, "/intel/iostat/device/*/svctm")
+		So(namespaces, ShouldContain, "/intel/iostat/device/*/w_await")
+		So(namespaces, ShouldContain, "/intel/iostat/device/*/w_per_sec")
+		So(namespaces, ShouldContain, "/intel/iostat/device/*/wkB_per_sec")
+		So(namespaces, ShouldContain, "/intel/iostat/device/*/wrqm_per_sec")
 	})
 
 	Convey("Get config policy", t, func() {

--- a/iostat/parser/parser.go
+++ b/iostat/parser/parser.go
@@ -14,7 +14,6 @@ import (
 
 const (
 	NsVendor = "intel"
-	NsClass  = "linux"
 	NsType   = "iostat"
 
 	defaultEmptyTokenAcceptance = 5
@@ -175,7 +174,7 @@ func joinNamespace(ns []string) string {
 	return "/" + strings.Join(ns, "/")
 }
 
-// createNamespace returns namespace slice of strings composed from: vendor, class, type and ceph-daemon name
+// createNamespace returns namespace slice of strings composed from: vendor, type and ceph-daemon name
 func createNamespace(name string) []string {
-	return []string{NsVendor, NsClass, NsType, name}
+	return []string{NsVendor, NsType, name}
 }


### PR DESCRIPTION
Namespaces were not following plugin standard `/org/name/...`

Summary of changes:
- Update namespaces to `/intel/iostat/...`
- Update documentation and examples.
- Upgrade plugin version