### PR TITLE
Adds large tests to plugin catalog metadata

### DIFF
--- a/metadata.yml
+++ b/metadata.yml
@@ -1,0 +1,11 @@
+name: iostat
+type: collector
+maintainer: core
+license: Apache-2.0
+description: "Collects Linux iostat metrics" 
+badge:
+  - "[![Build Status](https://travis-ci.org/intelsdi-x/snap-plugin-collector-iostat.svg?branch=master)](https://travis-ci.org/intelsdi-x/snap-plugin-collector-iostat)"
+  - "[![Build Status](https://ci.snap-telemetry.io/job/snap-plugin-collector-iostat-ec2-periodic/badge/icon)](https://ci.snap-telemetry.io/job/snap-plugin-collector-iostat-ec2-periodic/)"
+ci:
+  - https://travis-ci.org/intelsdi-x/snap-plugin-collector-iostat
+  - https://ci.snap-telemetry.io/job/snap-plugin-collector-iostat-ec2-periodic


### PR DESCRIPTION
This will allow for [plugin sync](https://github.com/intelsdi-x/snap-pluginsync) to add a build status to the plugin catalog similar to what was done manually in intelsdi-x/snap@05da827