### PR TITLE
Fixes #11, add iostat version check

### DIFF
--- a/iostat/command/command.go
+++ b/iostat/command/command.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"os/exec"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 type cmdRunner struct{}
@@ -34,4 +36,13 @@ func (c *cmdRunner) Run(cmd string, args []string) (io.Reader, error) {
 	case <-timer:
 		return nil, fmt.Errorf("time out (cmd:%v args:%v)", cmd, args)
 	}
+}
+
+func (c *cmdRunner) Exec(cmd string, args []string) string {
+	command := exec.Command(cmd, args...)
+	outputBytes, err := command.CombinedOutput()
+	if err != nil {
+		log.Error(err)
+	}
+	return string(outputBytes[:])
 }

--- a/iostat/iostat.go
+++ b/iostat/iostat.go
@@ -47,10 +47,12 @@ const (
 
 type runsCmd interface {
 	Run(cmd string, args []string) (io.Reader, error)
+	Exec(cmd string, args []string) string
 }
 
 type parses interface {
 	Parse(io.Reader) ([]string, map[string]float64, error)
+	ParseVersion(string) ([]int64, error)
 }
 
 // IOSTAT

--- a/iostat/iostat_test.go
+++ b/iostat/iostat_test.go
@@ -138,6 +138,9 @@ var refMap = map[string]interface{}{
 	"/intel/iostat/device/sda1/r_per_sec":    0,
 }
 
+var mockExecOut = `sysstat version 11.2.0
+(C) Sebastien Godard (sysstat <at> orange.fr)
+`
 var mockCmdOut = `Linux 3.10.0-229.11.1.el7.x86_64 (gklab-108-166) 0/26/2015      _x86_64_        (8 CPU)
 
 			10/26/2015 06:36:57 AM
@@ -225,6 +228,10 @@ type mockCmdRunner struct{}
 
 func (c *mockCmdRunner) Run(cmd string, args []string) (io.Reader, error) {
 	return strings.NewReader(mockCmdOut), nil
+}
+
+func (c *mockCmdRunner) Exec(cmd string, args []string) string {
+	return mockExecOut
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/iostat/parser/parser.go
+++ b/iostat/parser/parser.go
@@ -151,6 +151,31 @@ func (p *parser) parse(data string) error {
 	return nil
 }
 
+// returns version of iostat as [3]int
+func (p *parser) ParseVersion(versionString string) ([]int64, error) {
+	//verionString should be like "systat version %d.%d.%d \n[...]"
+	//so now versionWords[2] should be version in format "%d.%d.%d"
+	versionWords := strings.Split(versionString, "\n")
+	versionWords = strings.Split(versionWords[0], " ")
+	if len(versionWords) < 3 {
+		return nil, fmt.Errorf("Iostat version format has changed. Was \"sysstat version %%d.%%d.%%d\"")
+	}
+	//versionStrNums should be []string{"%d","%d","%d"}
+	versionNumsStr := strings.Split(versionWords[2], ".")
+	if len(versionNumsStr) < 3 {
+		return nil, fmt.Errorf("Iostat version format has changed. Was \"sysstat version %%d.%%d.%%d\"")
+	}
+	version := make([]int64, 0)
+	for _, numStr := range versionNumsStr {
+		temp, err := strconv.ParseInt(numStr, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		version = append(version, temp)
+	}
+	return version, nil
+}
+
 // replacePerSec turns "/s" into "_per_sec"
 func replaceByPerSec(slice []string) []string {
 	for i, str := range slice {


### PR DESCRIPTION
Fixes #11
Closes #11
Summary of changes:

add version check of iostat
How to verify it:

test on CentOS6 (or other system with iostat version < 10.2.0)
Testing done:

iostat wih version >= 10.2 => plugin loaded correctly
iostat wih version < 10.2 => plugin calls propor error
A picture of a snapping turtle :
http://rivista-cdn.reptilesmagazine.com/snapper2.jpg?ver=1441145036